### PR TITLE
Coloured reporting and Template Haskell runner

### DIFF
--- a/hedgehog.cabal
+++ b/hedgehog.cabal
@@ -34,15 +34,17 @@ source-repository head
 library
   build-depends:
       base                            >= 3          && < 5
-    , base64-bytestring               >= 1.0        && < 1.1
+    , ansi-terminal                   >= 0.6        && < 0.7
     , bytestring                      >= 0.10       && < 0.11
     , containers                      >= 0.4        && < 0.6
     , mmorph                          >= 1.0        && < 1.1
     , pretty-show                     >= 1.6        && < 1.7
     , random                          >= 1.1        && < 1.2
+    , template-haskell                >= 2.10       && < 2.12
     , text                            >= 1.1        && < 1.3
     , time                            >= 1.4        && < 1.9
     , transformers                    >= 0.3        && < 0.6
+    , wl-pprint-annotated             >= 0.0        && < 0.1
 
   if impl(ghc < 8.0)
     build-depends:
@@ -55,10 +57,15 @@ library
     src
 
   exposed-modules:
+    Hedgehog.Example
     Hedgehog.Gen
     Hedgehog.Property
     Hedgehog.Range
+    Hedgehog.Runner
+    Hedgehog.TH
 
+    Hedgehog.Internal.Discovery
+    Hedgehog.Internal.Report
     Hedgehog.Internal.Seed
     Hedgehog.Internal.Shrink
     Hedgehog.Internal.Tree
@@ -81,7 +88,6 @@ test-suite test
     , base                            >= 3          && < 5
     , containers                      >= 0.4        && < 0.6
     , pretty-show                     >= 1.6        && < 1.7
-    , QuickCheck                      >= 2.8.2      && < 2.9
     , text                            >= 1.1        && < 1.3
     , transformers                    >= 0.3        && < 0.6
 

--- a/src/Hedgehog/Internal/Discovery.hs
+++ b/src/Hedgehog/Internal/Discovery.hs
@@ -1,0 +1,229 @@
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE LambdaCase #-}
+module Hedgehog.Internal.Discovery (
+    PropertyName(..)
+  , PropertySource(..)
+  , readProperties
+  , findProperties
+  , readDeclaration
+
+  , Pos(..)
+  , Position(..)
+  ) where
+
+import           Control.Monad.IO.Class (MonadIO(..))
+
+import qualified Data.Char as Char
+import qualified Data.List as List
+import           Data.Map (Map)
+import qualified Data.Map as Map
+import qualified Data.Ord as Ord
+import           Data.Semigroup (Semigroup(..))
+
+------------------------------------------------------------------------
+-- Property Extraction
+
+newtype PropertyName =
+  PropertyName {
+      unPropertyName :: String
+    } deriving (Eq, Ord, Show)
+
+newtype PropertySource =
+  PropertySource {
+      propertySource :: Pos String
+    } deriving (Eq, Ord, Show)
+
+readProperties :: MonadIO m => FilePath -> m (Map PropertyName PropertySource)
+readProperties path = do
+  findProperties path <$> liftIO (readFile path)
+
+readDeclaration :: MonadIO m => FilePath -> Int -> m (Maybe (String, Pos String))
+readDeclaration path line = do
+  decls <- findDeclarations path <$> liftIO (readFile path)
+  pure .
+    takeHead .
+    List.sortBy (Ord.comparing $ Ord.Down . posLine . posPostion . snd) .
+    filter ((<= line) . posLine . posPostion . snd) $
+    Map.toList decls
+
+takeHead :: [a] -> Maybe a
+takeHead = \case
+  [] ->
+    Nothing
+  x : _ ->
+    Just x
+
+findProperties :: FilePath -> String -> Map PropertyName PropertySource
+findProperties path =
+  Map.map PropertySource .
+  Map.mapKeysMonotonic PropertyName .
+  Map.filterWithKey (\k _ -> isProperty k) .
+  findDeclarations path
+
+findDeclarations :: FilePath -> String -> Map String (Pos String)
+findDeclarations path =
+  declarations .
+  classified .
+  positioned path
+
+isProperty :: String -> Bool
+isProperty =
+  List.isPrefixOf "prop_"
+
+------------------------------------------------------------------------
+-- Declaration Identification
+
+declarations :: [Classified (Pos Char)] -> Map String (Pos String)
+declarations =
+  let
+    loop = \case
+      [] ->
+        []
+      x : xs ->
+        let
+          (ys, zs) =
+            break isDeclaration xs
+        in
+          tagWithName (forget x $ trimEnd ys) : loop zs
+  in
+    Map.fromListWith (<>) . loop . dropWhile (not . isDeclaration)
+
+trimEnd :: [Classified (Pos Char)] -> [Classified (Pos Char)]
+trimEnd xs =
+  let
+    (space0, code) =
+      span isWhitespace $ reverse xs
+
+    (line_tail0, space) =
+      span (\(Classified _ (Pos _ x)) -> x /= '\n') $
+      reverse space0
+
+    line_tail =
+      case space of
+        [] ->
+          line_tail0
+        x : _ ->
+          line_tail0 ++ [x]
+  in
+    reverse code ++ line_tail
+
+isWhitespace :: Classified (Pos Char) -> Bool
+isWhitespace (Classified c (Pos _ x)) =
+  c == Comment ||
+  Char.isSpace x
+
+tagWithName :: Pos String -> (String, Pos String)
+tagWithName (Pos p x) =
+  (takeName x, Pos p x)
+
+takeName :: String -> String
+takeName xs =
+  case words xs of
+    [] ->
+      ""
+    x : _ ->
+      x
+
+forget :: Classified (Pos Char) -> [Classified (Pos Char)] -> Pos String
+forget (Classified _ (Pos p x)) xs =
+  Pos p $
+    x : fmap (posValue . classifiedValue) xs
+
+isDeclaration :: Classified (Pos Char) -> Bool
+isDeclaration (Classified c (Pos p x)) =
+  c == NotComment &&
+  posColumn p == 1 &&
+  (Char.isLower x || x == '_')
+
+------------------------------------------------------------------------
+-- Comment Classification
+
+data Class =
+    NotComment
+  | Comment
+    deriving (Eq, Ord, Show)
+
+data Classified a =
+  Classified {
+      _classifiedClass :: !Class
+    , classifiedValue :: !a
+    } deriving (Eq, Ord, Show)
+
+classified :: [Pos Char] -> [Classified (Pos Char)]
+classified =
+  let
+    ok =
+      Classified NotComment
+
+    ko =
+      Classified Comment
+
+    loop nesting in_line = \case
+      [] ->
+        []
+
+      x@(Pos _ '\n') : xs | in_line ->
+        ok x : loop nesting False xs
+
+      x : xs | in_line ->
+        ko x : loop nesting in_line xs
+
+      x@(Pos _ '{') : y@(Pos _ '-') : xs ->
+        ko x : ko y : loop (nesting + 1) in_line xs
+
+      x@(Pos _ '-') : y@(Pos _ '}') : xs | nesting > 0 ->
+        ko x : ko y : loop (nesting - 1) in_line xs
+
+      x : xs | nesting > 0 ->
+        ko x : loop nesting in_line xs
+
+      -- FIXME This is not technically correct, we should allow arbitrary runs
+      -- FIXME of dashes followed by a symbol character. Here we have only
+      -- FIXME allowed two.
+      x@(Pos _ '-') : y@(Pos _ '-') : z@(Pos _ zz) : xs
+        | not (Char.isSymbol zz)
+        ->
+          ko x : ko y : loop nesting True (z : xs)
+
+      x : xs ->
+        ok x : loop nesting in_line xs
+  in
+    loop (0 :: Int) False
+
+------------------------------------------------------------------------
+-- Character Positioning
+
+data Position =
+  Position {
+      _posPath :: !FilePath
+    , posLine :: !Int
+    , posColumn :: !Int
+    } deriving (Eq, Ord, Show)
+
+data Pos a =
+  Pos {
+      posPostion :: !Position
+    , posValue :: a
+    } deriving (Eq, Ord, Show, Functor)
+
+instance Semigroup a => Semigroup (Pos a) where
+  (<>) (Pos p x) (Pos q y) =
+    if p < q then
+      Pos p (x <> y)
+    else
+      Pos q (y <> x)
+
+positioned :: FilePath -> [Char] -> [Pos Char]
+positioned path =
+  let
+    loop l c = \case
+      [] ->
+        []
+
+      '\n' : xs ->
+        Pos (Position path l c) '\n' : loop (l + 1) 1 xs
+
+      x : xs ->
+        Pos (Position path l c) x : loop l (c + 1) xs
+  in
+    loop 1 1

--- a/src/Hedgehog/Internal/Report.hs
+++ b/src/Hedgehog/Internal/Report.hs
@@ -1,0 +1,611 @@
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DoAndIfThenElse #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections #-}
+module Hedgehog.Internal.Report (
+  -- * Report
+    Report(..)
+  , Status(..)
+  , Failure(..)
+  , FailedInput(..)
+
+  , ShrinkCount
+  , SuccessCount
+  , DiscardCount
+
+  , Style(..)
+  , Markup(..)
+
+  , printReport
+  , ppReport
+
+  , mkFailure
+  ) where
+
+import           Control.Monad.IO.Class (MonadIO(..))
+import           Control.Monad.Trans.Maybe (MaybeT(..))
+
+import           Data.Bifunctor (bimap, first, second)
+import qualified Data.Char as Char
+import qualified Data.List as List
+import           Data.Map (Map)
+import qualified Data.Map as Map
+import           Data.Maybe (mapMaybe, catMaybes)
+import           Data.Semigroup (Semigroup(..))
+import           Data.Typeable (TypeRep)
+
+import           GHC.Stack (SrcLoc(..))
+
+import           Hedgehog.Internal.Discovery (Pos(..), Position(..))
+import qualified Hedgehog.Internal.Discovery as Discovery
+import           Hedgehog.Internal.Seed (Seed)
+import           Hedgehog.Property (Log(..))
+import           Hedgehog.Range (Size)
+
+import           System.Console.ANSI (ColorIntensity(..), Color(..))
+import           System.Console.ANSI (ConsoleLayer(..), ConsoleIntensity(..))
+import           System.Console.ANSI (SGR(..), setSGRCode, hSupportsANSI)
+import           System.Environment (getArgs)
+import           System.IO (stdout)
+
+import           Text.PrettyPrint.Annotated.WL (Doc, (<+>))
+import qualified Text.PrettyPrint.Annotated.WL as WL
+import           Text.Printf (printf)
+
+------------------------------------------------------------------------
+-- Data
+
+-- | The numbers of times a property was able to shrink after a failing test.
+--
+newtype ShrinkCount =
+  ShrinkCount Int
+  deriving (Eq, Ord, Show, Num, Enum, Real, Integral)
+
+-- | The number of tests a property ran successfully.
+--
+newtype SuccessCount =
+  SuccessCount Int
+  deriving (Eq, Ord, Show, Num, Enum, Real, Integral)
+
+-- | The number of tests a property had to discard.
+--
+newtype DiscardCount =
+  DiscardCount Int
+  deriving (Eq, Ord, Show, Num, Enum, Real, Integral)
+
+data FailedInput =
+  FailedInput {
+      failedSrcLoc :: !SrcLoc
+    , failedType :: !TypeRep
+    , failedValue :: !String
+    } deriving (Eq, Show)
+
+data Failure =
+  Failure {
+      failureSize :: !Size
+    , failureSeed :: !Seed
+    , failureShrinks :: !ShrinkCount
+    , failureInputs :: ![FailedInput]
+    , failureLocation :: !SrcLoc
+    , failureInfo :: ![String]
+    } deriving (Eq, Show)
+
+-- | The status of a property test run.
+--
+--   In the case of a failure it provides the seed used for the test, the
+--   number of shrinks, and the execution log.
+--
+data Status =
+    Failed !Failure
+  | GaveUp
+  | OK
+    deriving (Eq, Show)
+
+-- | The reporty from a property test run.
+--
+data Report =
+  Report {
+      reportTests :: !SuccessCount
+    , reportDiscards :: !DiscardCount
+    , reportStatus :: !Status
+    } deriving (Show)
+
+------------------------------------------------------------------------
+-- Pretty Printing Helpers
+
+newtype LineNo =
+  LineNo {
+      unLineNo :: Int
+    } deriving (Eq, Ord, Show, Num, Enum, Real, Integral)
+
+newtype ColumnNo =
+  ColumnNo {
+      _unColumnNo :: Int
+    } deriving (Eq, Ord, Show, Num, Enum, Real, Integral)
+
+data Line a =
+  Line {
+      _lineAnnotation :: !a
+    , lineNumber :: !LineNo
+    , _lineSource :: !String
+    } deriving (Eq, Ord, Show, Functor)
+
+data Declaration a =
+  Declaration {
+      declarationFile :: !FilePath
+    , declarationLine :: !LineNo
+    , _declarationName :: !String
+    , declarationSource :: !(Map LineNo (Line a))
+    } deriving (Eq, Ord, Show, Functor)
+
+data Style =
+    StyleInfo
+  | StyleInput
+  | StyleFailure
+    deriving (Eq, Ord, Show)
+
+data Markup =
+    FailedIcon
+  | FailedHeader
+  | GaveUpIcon
+  | GaveUpHeader
+  | SuccessIcon
+  | SuccessHeader
+  | DeclarationLocation
+  | StyledLineNo !Style
+  | StyledBorder !Style
+  | StyledSource !Style
+  | InputValue
+  | FailureArrows
+  | FailureMessage
+  | ReproduceHeader
+  | ReproduceGutter
+  | ReproduceSource
+    deriving (Eq, Ord, Show)
+
+instance Semigroup Style where
+  (<>) x y =
+    case (x, y) of
+      (StyleFailure, _) ->
+        StyleFailure
+      (_, StyleFailure) ->
+        StyleFailure
+      (StyleInput, _) ->
+        StyleInput
+      (_, StyleInput) ->
+        StyleInput
+      (StyleInfo, _) ->
+        StyleInfo
+
+------------------------------------------------------------------------
+
+takeInput :: Log -> Maybe FailedInput
+takeInput = \case
+  Input loc typ val ->
+    Just $ FailedInput loc typ val
+  _ ->
+    Nothing
+
+takeInfo :: Log -> Maybe String
+takeInfo = \case
+  Info x ->
+    Just x
+  _ ->
+    Nothing
+
+mkFailure :: Size -> Seed -> ShrinkCount -> SrcLoc -> [Log] -> Failure
+mkFailure size seed shrinks location logs =
+  let
+    inputs =
+      mapMaybe takeInput logs
+
+    info =
+      mapMaybe takeInfo logs
+  in
+    Failure size seed shrinks inputs location info
+
+------------------------------------------------------------------------
+-- Pretty Printing
+
+ppShow :: Show x => x -> Doc a
+ppShow = -- unfortunate naming clash
+  WL.text . show
+
+markup :: Markup -> Doc Markup -> Doc Markup
+markup =
+  WL.annotate
+
+gutter :: Markup -> Doc Markup -> Doc Markup
+gutter m x =
+  markup m ">" <+> x
+
+icon :: Markup -> Char -> Doc Markup -> Doc Markup
+icon m i x =
+  markup m (WL.char i) <+> x
+
+ppSuccessCount :: SuccessCount -> Doc a
+ppSuccessCount = \case
+  SuccessCount 1 ->
+    "1 test"
+  SuccessCount n ->
+    ppShow n <+> "tests"
+
+ppDiscardCount :: DiscardCount -> Doc a
+ppDiscardCount = \case
+  DiscardCount 1 ->
+    "1 discard"
+  DiscardCount n ->
+    ppShow n <+> "discards"
+
+ppShrinkCount :: ShrinkCount -> Doc a
+ppShrinkCount = \case
+  ShrinkCount 1 ->
+    "1 shrink"
+  ShrinkCount n ->
+    ppShow n <+> "shrinks"
+
+ppShrinkDiscard :: ShrinkCount -> DiscardCount -> Doc Markup
+ppShrinkDiscard s d =
+  case (s, d) of
+    (0, 0) ->
+      ""
+    (0, _) ->
+      " and" <+> ppDiscardCount d
+    (_, 0) ->
+      " and" <+> ppShrinkCount s
+    (_, _) ->
+      "," <+> ppShrinkCount s <+> "and" <+> ppDiscardCount d
+
+mapSource :: (Map LineNo (Line a) -> Map LineNo (Line a)) -> Declaration a -> Declaration a
+mapSource f decl =
+  decl {
+      declarationSource =
+        f (declarationSource decl)
+    }
+
+-- | The span of non-whitespace characters for the line.
+--
+--   The result is @[inclusive, exclusive)@.
+--
+lineSpan :: Line a -> (ColumnNo, ColumnNo)
+lineSpan (Line _ _ x0) =
+  let
+    (pre, x1) =
+      span Char.isSpace x0
+
+    (_, x2) =
+      span Char.isSpace (reverse x1)
+
+    start =
+      length pre
+
+    end =
+      start + length x2
+  in
+    (fromIntegral start, fromIntegral end)
+
+takeLines :: SrcLoc -> Declaration a -> Map LineNo (Line a)
+takeLines sloc =
+  fst . Map.split (fromIntegral $ srcLocEndLine sloc + 1) .
+  snd . Map.split (fromIntegral $ srcLocStartLine sloc - 1) .
+  declarationSource
+
+readDeclaration :: MonadIO m => SrcLoc -> m (Maybe (Declaration ()))
+readDeclaration sloc =
+  runMaybeT $ do
+    (name, Pos (Position _ line0 _) src) <- MaybeT $
+      Discovery.readDeclaration (srcLocFile sloc) (srcLocEndLine sloc)
+
+    let
+      path =
+        srcLocFile sloc
+
+      line =
+        fromIntegral line0
+
+    pure . Declaration path line name .
+      Map.fromList .
+      zip [line..] .
+      zipWith (Line ()) [line..] $
+      lines src
+
+
+defaultStyle :: Declaration a -> Declaration (Style, [(Style, Doc Markup)])
+defaultStyle =
+  fmap $ const (StyleInfo, [])
+
+lastLineSpan :: Monad m => SrcLoc -> Declaration a -> MaybeT m (ColumnNo, ColumnNo)
+lastLineSpan sloc decl =
+  case reverse . Map.elems $ takeLines sloc decl of
+    [] ->
+      MaybeT $ pure Nothing
+    x : _ ->
+      pure $
+        lineSpan x
+
+ppFailedInput ::
+  MonadIO m =>
+  FailedInput ->
+  m (Maybe (Declaration (Style, [(Style, Doc Markup)])))
+ppFailedInput (FailedInput sloc _ val) =
+  runMaybeT $ do
+    decl <- fmap defaultStyle . MaybeT $ readDeclaration sloc
+    startCol <- fromIntegral . fst <$> lastLineSpan sloc decl
+
+    let
+      code =
+        WL.indent startCol .
+        markup InputValue .
+        (WL.text "│ " <>) .
+        WL.text
+
+      docs =
+        fmap ((StyleInput, ) . code) $
+        List.lines val
+
+      endLine =
+        fromIntegral $ srcLocEndLine sloc
+
+      --TODO do we even want this?
+      --padding =
+      -- -- We only add padding after inputs if the next line contains code
+      -- case Map.lookup (endLine + 1) (declarationSource decl) of
+      --   Nothing ->
+      --     []
+      --   Just line ->
+      --     if all Char.isSpace (lineSource line) then
+      --       []
+      --     else
+      --       [(StyleInput, mempty)]
+
+      insertDoc =
+        Map.adjust (fmap . second $ const docs) endLine
+
+    pure $
+      mapSource insertDoc decl
+
+ppFailureLocation ::
+  MonadIO m =>
+  SrcLoc ->
+  m (Maybe (Declaration (Style, [(Style, Doc Markup)])))
+ppFailureLocation sloc =
+  runMaybeT $ do
+    decl <- fmap defaultStyle . MaybeT $ readDeclaration sloc
+    (startCol, endCol) <- bimap fromIntegral fromIntegral <$> lastLineSpan sloc decl
+
+    let
+      doc =
+        WL.indent startCol $
+          markup FailureArrows (WL.text (replicate (endCol - startCol) '^')) <+>
+          markup FailureMessage (WL.text "proposition was falsifiable!")
+
+      startLine =
+        fromIntegral $ srcLocStartLine sloc
+
+      endLine =
+        fromIntegral $ srcLocEndLine sloc
+
+      styleFailure kvs =
+        foldr (Map.adjust . fmap . first $ const StyleFailure) kvs [startLine..endLine]
+
+      insertDoc =
+        Map.adjust (fmap . second $ const [(StyleFailure, doc)]) endLine
+
+    pure $
+      mapSource (styleFailure . insertDoc) decl
+
+ppDeclaration :: Declaration (Style, [(Style, Doc Markup)]) -> Doc Markup
+ppDeclaration decl =
+  case Map.maxView $ declarationSource decl of
+    Nothing ->
+      mempty
+    Just (lastLine, _) ->
+      let
+        ppLocation =
+          WL.indent (digits + 1) $
+            markup (StyledBorder StyleInfo) "┏━━" <+>
+            markup DeclarationLocation (WL.text (declarationFile decl)) <+>
+            markup (StyledBorder StyleInfo) "━━━"
+
+        digits =
+          length . show . unLineNo $ lineNumber lastLine
+
+        ppLineNo =
+          WL.text . printf ("%" <> show digits <> "d") . unLineNo
+
+        ppEmptyNo =
+          WL.text $ replicate digits ' '
+
+        ppSource style n src =
+          markup (StyledLineNo style) (ppLineNo n) <+>
+          markup (StyledBorder style) "┃" <+>
+          markup (StyledSource style) (WL.text src)
+
+        ppAnnot (style, doc) =
+          markup (StyledLineNo style) ppEmptyNo <+>
+          markup (StyledBorder style) "┃" <+>
+          doc
+
+        ppLines = do
+          Line (style, xs) n src <- Map.elems $ declarationSource decl
+          ppSource style n src : fmap ppAnnot xs
+      in
+        WL.vsep (ppLocation : ppLines)
+
+ppReproduce :: Maybe String -> Size -> Seed -> Doc Markup
+ppReproduce name size seed =
+  WL.vsep [
+      markup ReproduceHeader
+        "This failure can be reproduced by running:"
+    , gutter ReproduceGutter . markup ReproduceSource $
+        "recheck" <+>
+        WL.text (showsPrec 11 size "") <+>
+        WL.text (showsPrec 11 seed "") <+>
+        maybe "<property>" WL.text name
+    ]
+
+mergeLine :: Semigroup a => Line a -> Line a -> Line a
+mergeLine (Line x no src) (Line y _ _) =
+  Line (x <> y) no src
+
+mergeDeclaration :: Semigroup a => Declaration a -> Declaration a -> Declaration a
+mergeDeclaration (Declaration file line name src0) (Declaration _ _ _ src1) =
+  Declaration file line name $
+  Map.unionWith mergeLine src0 src1
+
+mergeDeclarations :: Semigroup a => [Declaration a] -> [Declaration a]
+mergeDeclarations =
+  Map.elems .
+  Map.fromListWith mergeDeclaration .
+  fmap (\d -> ((declarationFile d, declarationLine d), d))
+
+ppFailure :: MonadIO m => Maybe String -> Failure -> m (Doc Markup)
+ppFailure name (Failure size seed _ inputs0 location0 msgs) = do
+  mlocation <- ppFailureLocation location0
+  minputs <- traverse ppFailedInput inputs0
+
+  let
+    decls =
+      mergeDeclarations .
+      catMaybes $
+        mlocation : minputs
+
+  pure . WL.indent 2 . WL.vsep . WL.punctuate WL.line $ [
+      WL.vsep . WL.punctuate WL.line $ fmap ppDeclaration decls
+    ] <> (if null msgs then [] else [WL.vsep $ fmap WL.text msgs]) <> [
+      ppReproduce name size seed
+    ]
+
+ppName :: Maybe String -> Doc a
+ppName = \case
+  Nothing ->
+    "<interactive>"
+  Just name ->
+    WL.text name
+
+ppReport :: MonadIO m => Maybe String -> Report -> m (Doc Markup)
+ppReport name (Report successes discards status) =
+  case status of
+    Failed failure -> do
+      pfailure <- ppFailure name failure
+      pure . WL.vsep $ [
+          icon FailedIcon '✗' . WL.annotate FailedHeader $
+            ppName name <+>
+            "failed after" <+>
+            ppSuccessCount successes <>
+            ppShrinkDiscard (failureShrinks failure) discards <>
+            "."
+        , mempty
+        , pfailure
+        , mempty
+        ]
+    GaveUp ->
+      pure . icon GaveUpIcon '⚐' . WL.annotate GaveUpHeader $
+        ppName name <+>
+        "gave up after" <+>
+        ppDiscardCount discards <>
+        ", passed" <+>
+        ppSuccessCount successes <>
+        "."
+    OK ->
+      pure . icon SuccessIcon '✓' . WL.annotate SuccessHeader $
+        ppName name <+>
+        "passed" <+>
+        ppSuccessCount successes <>
+        "."
+
+useColor :: MonadIO m => m Bool
+useColor = do
+  -- FIXME This is pretty savage, not sure how else to provide this while
+  -- FIXME maintain a seamless experience. Maybe we should just go for a
+  -- FIXME HEDGEHOG_COLOR environment variable instead.
+  args <- liftIO getArgs
+  if elem "--color" args then
+    pure True
+  else if elem "--no-color" args then
+    pure False
+  else
+    liftIO $ hSupportsANSI stdout
+
+printReport :: MonadIO m => Maybe String -> Report -> m ()
+printReport name x = do
+  doc <- ppReport name x
+  color <- useColor
+
+  let
+    dull =
+      SetColor Foreground Dull
+
+    vivid =
+      SetColor Foreground Vivid
+
+    bold =
+      SetConsoleIntensity BoldIntensity
+
+    start = \case
+      FailedIcon ->
+        setSGRCode [dull Red]
+      FailedHeader ->
+        setSGRCode [vivid Red]
+      GaveUpIcon ->
+        setSGRCode [dull Yellow]
+      GaveUpHeader ->
+        setSGRCode [vivid Yellow]
+      SuccessIcon ->
+        setSGRCode [dull Green]
+      SuccessHeader ->
+        setSGRCode [vivid Green]
+
+      DeclarationLocation ->
+        setSGRCode []
+
+      StyledLineNo StyleInfo ->
+        setSGRCode []
+      StyledSource StyleInfo ->
+        setSGRCode []
+      StyledBorder StyleInfo ->
+        setSGRCode []
+
+      StyledLineNo StyleInput ->
+        setSGRCode [dull Magenta]
+      StyledSource StyleInput ->
+        setSGRCode []
+      StyledBorder StyleInput ->
+        setSGRCode []
+      InputValue ->
+        setSGRCode [dull Magenta]
+
+      StyledLineNo StyleFailure ->
+        setSGRCode [vivid Red]
+      StyledSource StyleFailure ->
+        setSGRCode [vivid Red, bold]
+      StyledBorder StyleFailure ->
+        setSGRCode [vivid Red]
+      FailureArrows ->
+        setSGRCode [vivid Red]
+      FailureMessage ->
+        setSGRCode [vivid Red]
+
+      ReproduceHeader ->
+        setSGRCode []
+      ReproduceGutter ->
+        setSGRCode []
+      ReproduceSource ->
+        setSGRCode []
+
+    end _ =
+      setSGRCode [Reset]
+
+    display =
+      if color then
+        WL.displayDecorated start end id
+      else
+        WL.display
+
+  liftIO .
+    putStrLn .
+    display .
+    WL.renderSmart 100 $
+    WL.indent 2 doc

--- a/src/Hedgehog/Property.hs
+++ b/src/Hedgehog/Property.hs
@@ -13,22 +13,11 @@ module Hedgehog.Property (
   , discard
   , failure
   , success
-  , assert
+  , ensure
   , (===)
-
-  -- * Reporting
-  , Report(..)
-  , Status(..)
-  , ShrinkCount
-  , SuccessCount
-  , DiscardCount
-  , check
-  , recheck
-  , report
 
   -- * Internal
   -- $internal
-  -- ** Property
   , writeLog
   , runProperty
   ) where
@@ -37,18 +26,16 @@ import           Control.Applicative (Alternative(..))
 import           Control.Monad (MonadPlus(..))
 import           Control.Monad.IO.Class (MonadIO(..))
 import           Control.Monad.Trans.Class (MonadTrans(..))
-import           Control.Monad.Trans.Maybe (MaybeT(..), runMaybeT)
+import           Control.Monad.Trans.Except (ExceptT(..), runExceptT)
 import           Control.Monad.Trans.Writer.Lazy (WriterT(..), tell)
 
 import           Data.String (IsString(..))
 import           Data.Typeable (Typeable, TypeRep, typeOf)
 
-import           Hedgehog.Gen (Gen, runGen)
+import           GHC.Stack
+
+import           Hedgehog.Gen (Gen)
 import qualified Hedgehog.Gen as Gen
-import           Hedgehog.Internal.Seed (Seed)
-import qualified Hedgehog.Internal.Seed as Seed
-import           Hedgehog.Internal.Tree (Tree(..), Node(..))
-import           Hedgehog.Range (Size)
 
 import           Text.Show.Pretty (ppShow)
 
@@ -56,13 +43,13 @@ import           Text.Show.Pretty (ppShow)
 
 newtype Property m a =
   Property {
-      unProperty :: MaybeT (WriterT [Log] (Gen m)) a
+      unProperty :: ExceptT SrcLoc (WriterT [Log] (Gen m)) a
     } deriving (Functor, Applicative, Monad)
 
 data Log =
-    ForAll Name TypeRep String
-  | Info String
-    deriving (Eq, Ord, Show)
+    Info String
+  | Input SrcLoc TypeRep String
+    deriving (Eq, Show)
 
 newtype Name =
   Name String
@@ -73,7 +60,7 @@ instance Monad m => MonadPlus (Property m) where
     discard
 
   mplus x y =
-    Property . MaybeT . WriterT $
+    Property . ExceptT . WriterT $
       mplus (runProperty x) (runProperty y)
 
 instance Monad m => Alternative (Property m) where
@@ -94,18 +81,26 @@ instance IsString Name where
   fromString =
     Name
 
-runProperty :: Property m a -> Gen m (Maybe a, [Log])
+runProperty :: Property m a -> Gen m (Either SrcLoc a, [Log])
 runProperty =
-  runWriterT . runMaybeT . unProperty
+  runWriterT . runExceptT . unProperty
 
 writeLog :: Monad m => Log -> Property m ()
 writeLog =
   Property . lift . tell . pure
 
-forAll :: (Show a, Typeable a, Monad m) => Name -> Gen m a -> Property m a
-forAll name gen = do
+takeSrcLoc :: CallStack -> SrcLoc
+takeSrcLoc stack =
+  case getCallStack stack of
+    [] ->
+      error "Hedgehog.Property.takeSrcLoc: unexpected empty call stack"
+    (_, x) : _ ->
+      x
+
+forAll :: (Monad m, Show a, Typeable a, HasCallStack) => Gen m a -> Property m a
+forAll gen = do
   x <- Property . lift $ lift gen
-  writeLog $ ForAll name (typeOf x) (ppShow x)
+  writeLog $ Input (takeSrcLoc callStack) (typeOf x) (ppShow x)
   return x
 
 info :: Monad m => String -> Property m ()
@@ -116,223 +111,29 @@ discard :: Monad m => Property m a
 discard =
   Property . lift $ lift Gen.discard
 
-failure :: Monad m => Property m a
+failure :: (Monad m, HasCallStack) => Property m a
 failure =
-  Property . MaybeT $ pure Nothing
+  Property . ExceptT . pure . Left $ takeSrcLoc callStack
 
 success :: Monad m => Property m ()
 success =
   Property $ pure ()
 
-assert :: Monad m => Bool -> Property m ()
-assert b =
+ensure :: (Monad m, HasCallStack) => Bool -> Property m ()
+ensure b =
   if b then
     success
-  else
-    failure
+  else do
+    withFrozenCallStack failure
 
 infix 4 ===
 
-(===) :: (Monad m, Eq a, Show a) => a -> a -> Property m ()
+(===) :: (Monad m, Eq a, Show a, HasCallStack) => a -> a -> Property m ()
 (===) x y =
   if x == y then
     success
   else do
-    info "=== Not Equal ==="
+    info "━━━ Not Equal ━━━"
     info (ppShow x)
     info (ppShow y)
-    failure
-
-------------------------------------------------------------------------
--- Reporting
-
--- | The numbers of times a property was able to shrink after a failing test.
---
-newtype ShrinkCount =
-  ShrinkCount Int
-  deriving (Eq, Ord, Show, Num, Enum, Real, Integral)
-
--- | The number of tests a property ran successfully.
---
-newtype SuccessCount =
-  SuccessCount Int
-  deriving (Eq, Ord, Show, Num, Enum, Real, Integral)
-
--- | The number of tests a property had to discard.
---
-newtype DiscardCount =
-  DiscardCount Int
-  deriving (Eq, Ord, Show, Num, Enum, Real, Integral)
-
--- | The status of a property test run.
---
---   In the case of a failure it provides the seed used for the test, the
---   number of shrinks, and the execution log.
---
-data Status =
-    Failed Size Seed ShrinkCount [Log]
-  | GaveUp
-  | OK
-    deriving (Show)
-
--- | The report from a property test run.
---
-data Report =
-  Report {
-      reportTests :: SuccessCount
-    , reportDiscards :: DiscardCount
-    , reportStatus :: Status
-    } deriving (Show)
-
-findM :: Monad m => [a] -> b -> (a -> m (Maybe b)) -> m b
-findM xs0 def p =
-  case xs0 of
-    [] ->
-      return def
-    x0 : xs ->
-      p x0 >>= \m ->
-        case m of
-          Nothing ->
-            findM xs def p
-          Just x ->
-            return x
-
-isFailure :: Node m (Maybe (Maybe a, b)) -> Bool
-isFailure = \case
-  Node (Just (Nothing, _)) _ ->
-    True
-  _ ->
-    False
-
-takeSmallest :: MonadIO m => Size -> Seed -> ShrinkCount -> Node m (Maybe (Maybe (), [Log])) -> m Status
-takeSmallest size seed (ShrinkCount n) = \case
-  Node Nothing _ ->
-    pure GaveUp
-
-  Node (Just (x, w)) xs ->
-    case x of
-      Nothing -> do
-        --liftIO $ putStrLn "*** Shrinking"
-        --liftIO . putStr . unlines $ fmap renderLog w
-        findM xs (Failed size seed (ShrinkCount n) w) $ \m -> do
-          o <- runTree m
-          if isFailure o then
-            Just <$> takeSmallest size seed (ShrinkCount $ n + 1) o
-          else
-            return Nothing
-
-      Just () ->
-        return OK
-
-report :: forall m. MonadIO m => SuccessCount -> Size -> Seed -> Property m () -> m Report
-report n size0 seed0 prop =
-  let
-    loop :: SuccessCount -> DiscardCount -> Size -> Seed -> m Report
-    loop !successes !discards !size !seed =
-      if size > 99 then
-        loop successes discards 0 seed
-      else if successes == n then
-        pure $ Report successes discards OK
-      else if discards >= 100 then
-        pure $ Report successes discards GaveUp
-      else
-        case Seed.split seed of
-          (s0, s1) -> do
-            node@(Node x _) <-
-              runTree . Gen.runDiscardEffect $ runGen size s0 (runProperty prop)
-            case x of
-              Nothing ->
-                loop successes (discards + 1) (size + 1) s1
-
-              Just (Nothing, _) ->
-                Report successes discards <$> takeSmallest size seed (ShrinkCount 0) node
-
-              Just (Just (), _) ->
-                loop (successes + 1) discards (size + 1) s1
-  in
-    loop 0 0 size0 seed0
-
-check :: MonadIO m => Property m () -> m ()
-check prop = do
-  seed <- liftIO Seed.random
-  printReport =<< report 100 0 seed prop
-
-recheck :: MonadIO m => Size -> Seed -> Property m () -> m ()
-recheck size seed prop =
-  printReport =<< report 1 size seed prop
-
-------------------------------------------------------------------------
--- Rendering
-
-printReport :: MonadIO m => Report -> m ()
-printReport (Report successes discards status) =
-  case status of
-    Failed size seed shrinks msgs -> do
-      liftIO . putStr . unlines $
-        [ "*** Failed! Falsifiable (after " ++
-            renderSuccessCount successes ++
-            renderShrinkDiscard shrinks discards ++
-            ")"
-        ] ++ fmap renderLog msgs ++ [
-          ""
-        , "This failure can be reproduced by running:"
-        , "> recheck " ++
-            showsPrec 11 size "" ++
-            " " ++
-            showsPrec 11 seed "" ++
-            " <property>"
-        ]
-    GaveUp ->
-      liftIO . putStrLn $
-        "*** Gave up after " ++
-        renderDiscardCount discards ++
-        ", passed " ++
-        renderSuccessCount successes ++
-        "."
-    OK ->
-      liftIO . putStrLn $
-        "+++ OK, passed " ++
-        renderSuccessCount successes ++
-        "."
-
-renderSuccessCount :: SuccessCount -> String
-renderSuccessCount = \case
-  SuccessCount 1 ->
-    "1 successful test"
-  SuccessCount n ->
-    show n ++ " successful tests"
-
-renderDiscardCount :: DiscardCount -> String
-renderDiscardCount = \case
-  DiscardCount 1 ->
-    "1 discard"
-  DiscardCount n ->
-    show n ++ " discards"
-
-renderShrinkCount :: ShrinkCount -> String
-renderShrinkCount = \case
-  ShrinkCount 1 ->
-    "1 shrink"
-  ShrinkCount n ->
-    show n ++ " shrinks"
-
-renderShrinkDiscard :: ShrinkCount -> DiscardCount -> String
-renderShrinkDiscard s d =
-  case (s, d) of
-    (0, 0) ->
-      ""
-    (0, _) ->
-      " and " ++ renderDiscardCount d
-    (_, 0) ->
-      " and " ++ renderShrinkCount s
-    (_, _) ->
-      ", " ++ renderShrinkCount s ++ " and " ++ renderDiscardCount d
-
-renderLog :: Log -> String
-renderLog = \case
-  ForAll (Name name) typ x ->
-    name ++ " :: " ++ show typ ++ "\n" ++
-    name ++ " =\n" ++
-    unlines (fmap ("  " ++) $ lines x)
-  Info msg ->
-    msg
+    withFrozenCallStack failure

--- a/src/Hedgehog/Runner.hs
+++ b/src/Hedgehog/Runner.hs
@@ -1,0 +1,117 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DoAndIfThenElse #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Hedgehog.Runner (
+  -- * Runner
+    check
+  , checkNamed
+  , recheck
+
+  -- * Internal
+  , checkReport
+  ) where
+
+import           Control.Monad.IO.Class (MonadIO(..))
+
+import           GHC.Stack (SrcLoc(..))
+
+import           Hedgehog.Gen (runGen)
+import qualified Hedgehog.Gen as Gen
+import           Hedgehog.Internal.Report
+import           Hedgehog.Internal.Seed (Seed)
+import qualified Hedgehog.Internal.Seed as Seed
+import           Hedgehog.Internal.Tree (Tree(..), Node(..))
+import           Hedgehog.Property (Property, Log(..), runProperty)
+import           Hedgehog.Range (Size)
+
+------------------------------------------------------------------------
+
+findM :: Monad m => [a] -> b -> (a -> m (Maybe b)) -> m b
+findM xs0 def p =
+  case xs0 of
+    [] ->
+      return def
+    x0 : xs ->
+      p x0 >>= \m ->
+        case m of
+          Nothing ->
+            findM xs def p
+          Just x ->
+            return x
+
+isFailure :: Node m (Maybe (Either x a, b)) -> Bool
+isFailure = \case
+  Node (Just (Left _, _)) _ ->
+    True
+  _ ->
+    False
+
+takeSmallest ::
+  MonadIO m =>
+  Size ->
+  Seed ->
+  ShrinkCount ->
+  Node m (Maybe (Either SrcLoc (), [Log])) -> m Status
+takeSmallest size seed shrinks = \case
+  Node Nothing _ ->
+    pure GaveUp
+
+  Node (Just (x, w)) xs ->
+    case x of
+      Left loc -> do
+        --liftIO $ putStrLn "*** Shrinking"
+        --liftIO . putStr . unlines $ fmap ppLog w
+        findM xs (Failed $ mkFailure size seed shrinks loc w) $ \m -> do
+          o <- runTree m
+          if isFailure o then
+            Just <$> takeSmallest size seed (shrinks + 1) o
+          else
+            return Nothing
+
+      Right () ->
+        return OK
+
+checkReport :: forall m. MonadIO m => SuccessCount -> Size -> Seed -> Property m () -> m Report
+checkReport n size0 seed0 prop =
+  let
+    loop :: SuccessCount -> DiscardCount -> Size -> Seed -> m Report
+    loop !successes !discards !size !seed =
+      if size > 99 then
+        loop successes discards 0 seed
+      else if successes == n then
+        pure $ Report successes discards OK
+      else if discards >= 100 then
+        pure $ Report successes discards GaveUp
+      else
+        case Seed.split seed of
+          (s0, s1) -> do
+            node@(Node x _) <-
+              runTree . Gen.runDiscardEffect $ runGen size s0 (runProperty prop)
+            case x of
+              Nothing ->
+                loop successes (discards + 1) (size + 1) s1
+
+              Just (Left _, _) ->
+                Report successes discards <$> takeSmallest size seed 0 node
+
+              Just (Right (), _) ->
+                loop (successes + 1) discards (size + 1) s1
+  in
+    loop 0 0 size0 seed0
+
+checkNamed :: MonadIO m => Maybe String -> Property m () -> m Bool
+checkNamed name prop = do
+  seed <- liftIO Seed.random
+  x <- checkReport 100 0 seed prop
+  printReport name x
+  pure $
+    reportStatus x == OK
+
+check :: MonadIO m => Property m () -> m Bool
+check =
+  checkNamed Nothing
+
+recheck :: MonadIO m => Size -> Seed -> Property m () -> m ()
+recheck size seed prop =
+  printReport Nothing =<< checkReport 1 size seed prop

--- a/src/Hedgehog/TH.hs
+++ b/src/Hedgehog/TH.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Hedgehog.TH where
+
+import qualified Data.List as List
+import qualified Data.Map as Map
+import qualified Data.Ord as Ord
+import           Data.Traversable (for)
+
+import           Hedgehog.Internal.Discovery
+import           Hedgehog.Property
+import           Hedgehog.Runner
+
+import           Language.Haskell.TH
+import           Language.Haskell.TH.Syntax
+
+type TExpQ a =
+  Q (TExp a)
+
+checkAll :: TExpQ (IO Bool)
+checkAll = do
+  file <- getCurrentFile
+  properties <- Map.toList <$> runIO (readProperties file)
+
+  let
+    startLine =
+      Ord.comparing $
+        posLine .
+        posPostion .
+        propertySource .
+        snd
+
+    names =
+      fmap (mkNamedProperty . fst) $
+      List.sortBy startLine properties
+
+  [|| runCheckAll $$(moduleName) $$(listTE names) ||]
+
+mkNamedProperty :: PropertyName -> TExpQ (String, Property IO ())
+mkNamedProperty name@(PropertyName x) = do
+  [|| (x, $$(unsafeProperty name)) ||]
+
+unsafeProperty :: PropertyName -> TExpQ (Property IO ())
+unsafeProperty =
+  unsafeTExpCoerce . pure . VarE . mkName . unPropertyName
+
+listTE :: [TExpQ a] -> TExpQ [a]
+listTE xs = do
+  unsafeTExpCoerce . pure . ListE =<< traverse unTypeQ xs
+
+moduleName :: TExpQ String
+moduleName = do
+  loc <- loc_module <$> location
+  [|| loc ||]
+
+getCurrentFile :: Q FilePath
+getCurrentFile =
+  loc_filename <$> location
+
+runCheckAll :: String -> [(String, Property IO ())] -> IO Bool
+runCheckAll modName ps = do
+  putStrLn $ "━━━ " ++ modName ++ " ━━━"
+  fmap and . for ps $ \(name, p) -> do
+    checkNamed (Just name) p

--- a/test/test.hs
+++ b/test/test.hs
@@ -2,12 +2,16 @@ import           Control.Monad (unless)
 import           System.IO (BufferMode(..), hSetBuffering, stdout, stderr)
 import           System.Exit (exitFailure)
 
+import qualified Hedgehog.Example as Hedgehog.Example
+
 main :: IO ()
 main = do
   hSetBuffering stdout LineBuffering
   hSetBuffering stderr LineBuffering
 
-  results <- sequence []
+  results <- sequence [
+      Hedgehog.Example.tests
+    ]
 
   unless (and results) $
     exitFailure


### PR DESCRIPTION
This significantly improves the test runner, adding coloured output 🌈 and some template haskell code for discovering properties.

<img width="426" alt="screen shot 2017-03-19 at 5 33 44 pm" src="https://cloud.githubusercontent.com/assets/134805/24078743/24cf66e0-0cca-11e7-93c7-facea403ff26.png">

The property discovery is a little hacky, but it does deal with multi-line comments, so the following will not be picked up as a property:
```hs
{-
prop_foo =
  not done yet
-}
```

The failure output pulls in the source code of the property and annotates it with the generated test data, as well as "calling out" which of your propositions actually failed. I can imagine this will be useful when you have a `conjoin` like thing with many possible ways in which you can fail:

<img width="564" alt="screen shot 2017-03-19 at 5 30 21 pm" src="https://cloud.githubusercontent.com/assets/134805/24078722/b73ebd6a-0cc9-11e7-8fbd-eb80b26c7215.png">

The source code annotation relies on the GHC 8.0 `CallStack` API, so I'm going to need to figure out something to do as a stop gap for use in GHC 7.10. I'll probably just go back to printing the forall's in a list along with their types if compiling for 7.10.

Ignore the churn on the `Example.hs` file, I was just playing with things to see what different failures would look like in the test runner. Hopefully the source code annotation stuff scales to larger examples, I'm not sure, but I think it should be ok.

My todo list before doing the first Hackage release is basically just adding examples for working with `IO`, `ResourceT` and `ExceptT` to see if there's any issues with Template Haskell property discovery stuff and the interface for monadic tests.