### PR TITLE
Add fallback rendering for 7.10

### DIFF
--- a/hedgehog.cabal
+++ b/hedgehog.cabal
@@ -73,6 +73,7 @@ library
     Hedgehog.Internal.Report
     Hedgehog.Internal.Seed
     Hedgehog.Internal.Shrink
+    Hedgehog.Internal.Source
     Hedgehog.Internal.Tree
 
 test-suite test

--- a/src/Hedgehog/Internal/Discovery.hs
+++ b/src/Hedgehog/Internal/Discovery.hs
@@ -20,6 +20,8 @@ import qualified Data.Map as Map
 import qualified Data.Ord as Ord
 import           Data.Semigroup (Semigroup(..))
 
+import           Hedgehog.Internal.Source (LineNo(..), ColumnNo(..))
+
 ------------------------------------------------------------------------
 -- Property Extraction
 
@@ -37,7 +39,7 @@ readProperties :: MonadIO m => FilePath -> m (Map PropertyName PropertySource)
 readProperties path = do
   findProperties path <$> liftIO (readFile path)
 
-readDeclaration :: MonadIO m => FilePath -> Int -> m (Maybe (String, Pos String))
+readDeclaration :: MonadIO m => FilePath -> LineNo -> m (Maybe (String, Pos String))
 readDeclaration path line = do
   decls <- findDeclarations path <$> liftIO (readFile path)
   pure .
@@ -196,8 +198,8 @@ classified =
 data Position =
   Position {
       _posPath :: !FilePath
-    , posLine :: !Int
-    , posColumn :: !Int
+    , posLine :: !LineNo
+    , posColumn :: !ColumnNo
     } deriving (Eq, Ord, Show)
 
 data Pos a =

--- a/src/Hedgehog/Internal/Source.hs
+++ b/src/Hedgehog/Internal/Source.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+module Hedgehog.Internal.Source (
+    LineNo(..)
+  , ColumnNo(..)
+  , Span(..)
+  , getCaller
+
+  -- * Re-exports from 'GHC.Stack'
+  , CallStack
+  , HasCallStack
+  , callStack
+  , withFrozenCallStack
+  ) where
+
+#if MIN_VERSION_base(4,9,0)
+import GHC.Stack (CallStack, HasCallStack, SrcLoc(..))
+import GHC.Stack (callStack, getCallStack, withFrozenCallStack)
+#else
+import GHC.Exts (Constraint)
+#endif
+
+newtype LineNo =
+  LineNo {
+      unLineNo :: Int
+    } deriving (Eq, Ord, Show, Num, Enum, Real, Integral)
+
+newtype ColumnNo =
+  ColumnNo {
+      unColumnNo :: Int
+    } deriving (Eq, Ord, Show, Num, Enum, Real, Integral)
+
+data Span =
+  Span {
+      spanFile :: !FilePath
+    , spanStartLine :: !LineNo
+    , spanStartColumn :: !ColumnNo
+    , spanEndLine :: !LineNo
+    , spanEndColumn :: !ColumnNo
+    } deriving (Eq, Ord, Show)
+
+#if !MIN_VERSION_base(4,9,0)
+type family HasCallStack :: Constraint where
+  HasCallStack = ()
+
+data CallStack =
+  CallStack
+  deriving (Show)
+
+callStack :: HasCallStack => CallStack
+callStack =
+  CallStack
+
+withFrozenCallStack :: HasCallStack => (HasCallStack => a) -> a
+withFrozenCallStack x =
+  x
+#endif
+
+getCaller :: CallStack -> Maybe Span
+#if MIN_VERSION_base(4,9,0)
+getCaller stack =
+  case getCallStack stack of
+    [] ->
+      Nothing
+    (_, x) : _ ->
+      Just $ Span
+        (srcLocFile x)
+        (fromIntegral $ srcLocStartLine x)
+        (fromIntegral $ srcLocStartCol x)
+        (fromIntegral $ srcLocEndLine x)
+        (fromIntegral $ srcLocEndCol x)
+#else
+getCaller _ =
+  Nothing
+#endif

--- a/src/Hedgehog/Runner.hs
+++ b/src/Hedgehog/Runner.hs
@@ -14,15 +14,13 @@ module Hedgehog.Runner (
 
 import           Control.Monad.IO.Class (MonadIO(..))
 
-import           GHC.Stack (SrcLoc(..))
-
 import           Hedgehog.Gen (runGen)
 import qualified Hedgehog.Gen as Gen
 import           Hedgehog.Internal.Report
 import           Hedgehog.Internal.Seed (Seed)
 import qualified Hedgehog.Internal.Seed as Seed
 import           Hedgehog.Internal.Tree (Tree(..), Node(..))
-import           Hedgehog.Property (Property, Log(..), runProperty)
+import           Hedgehog.Property (Property, Log(..), Failure(..), runProperty)
 import           Hedgehog.Range (Size)
 
 ------------------------------------------------------------------------
@@ -52,14 +50,14 @@ takeSmallest ::
   Size ->
   Seed ->
   ShrinkCount ->
-  Node m (Maybe (Either SrcLoc (), [Log])) -> m Status
+  Node m (Maybe (Either Failure (), [Log])) -> m Status
 takeSmallest size seed shrinks = \case
   Node Nothing _ ->
     pure GaveUp
 
   Node (Just (x, w)) xs ->
     case x of
-      Left loc -> do
+      Left (Failure loc) -> do
         --liftIO $ putStrLn "*** Shrinking"
         --liftIO . putStr . unlines $ fmap ppLog w
         findM xs (Failed $ mkFailure size seed shrinks loc w) $ \m -> do


### PR DESCRIPTION
This adds a fallback renderer for 7.10 because we can't get call stack information until GHC 8.0:

<img width="561" alt="screen shot 2017-03-19 at 9 15 55 pm" src="https://cloud.githubusercontent.com/assets/134805/24079984/405340b6-0ce9-11e7-8681-4ed3b447eb0e.png">

It's not too bad, certainly not as busy as the 8.0 output, but not as useful for diagnosing a failure either. This is also the output you would get in 8.0 now if the test runner failed to locate a file where an input supposedly came from.

The `Hedgehog.Internal.Source` module re-exports the parts of the `GHC.Stack` API that we need, and shims enough of it for 7.10 so we don't need CPP in the rest of the project.