### PR TITLE
Add top level Hedgehog module

### DIFF
--- a/hedgehog-example/test/Test/Example/Basic.hs
+++ b/hedgehog-example/test/Test/Example/Basic.hs
@@ -6,11 +6,9 @@ module Test.Example.Basic where
 
 import           Control.Monad (guard)
 
-import           Hedgehog.Gen (Gen)
+import           Hedgehog
 import qualified Hedgehog.Gen as Gen
-import           Hedgehog.Property
 import qualified Hedgehog.Range as Range
-import           Hedgehog.TH
 
 ------------------------------------------------------------------------
 -- Example 0
@@ -39,8 +37,8 @@ prop_commented_out_properties_do_not_run =
 -- Try 'check prop_foo' to see what happens
 prop_foo :: Monad m => Property m ()
 prop_foo = do
-  x <- forAll $ Gen.enum 'a' 'z'
-  y <- forAll $
+  x <- given $ Gen.enum 'a' 'z'
+  y <- given $
     Gen.choice [
         Gen.integral (Range.linear 0 1000)
       , Gen.integral (Range.linear 0 1000)
@@ -48,7 +46,7 @@ prop_foo = do
 
   guard (y `mod` 2 == (1 :: Int))
 
-  ensure $
+  assert $
     y < 87 && x <= 'r'
 
 ------------------------------------------------------------------------
@@ -124,8 +122,8 @@ order gen =
 --
 prop_total :: Monad m => Property m ()
 prop_total = do
-  x <- forAll (order $ Gen.choice [cheap, expensive])
-  y <- forAll (order expensive)
+  x <- given (order $ Gen.choice [cheap, expensive])
+  y <- given (order expensive)
   total (merge x y) === total x + total y
 
 ------------------------------------------------------------------------
@@ -161,10 +159,10 @@ genExp =
 
 prop_hutton :: Monad m => Property m ()
 prop_hutton = do
-  x <- forAll genExp
+  x <- given genExp
   case x of
     Add (Add _ _) _ ->
-      ensure (evalExp x < 100)
+      assert (evalExp x < 100)
     _ ->
       success
 

--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -62,6 +62,7 @@ library
     src
 
   exposed-modules:
+    Hedgehog
     Hedgehog.Gen
     Hedgehog.Property
     Hedgehog.Range

--- a/hedgehog/src/Hedgehog.hs
+++ b/hedgehog/src/Hedgehog.hs
@@ -1,0 +1,64 @@
+-- |
+-- This module includes almost everything you need to get started writing
+-- property tests with Hedgehog.
+--
+-- It is designed to be used alongside "Hedgehog.Gen" and "Hedgehog.Range",
+-- which should be imported qualified. You also need to enable Template Haskell
+-- so the Hedgehog test runner can find your properties.
+--
+-- > {-# LANGUAGE TemplateHaskell #-}
+-- >
+-- > import           Hedgehog
+-- > import qualified Hedgehog.Gen as Gen
+-- > import qualified Hedgehog.Range as Range
+--
+-- Once you have your imports set up, you can write a simple property:
+--
+-- > prop_reverse :: Monad m => Property m ()
+-- > prop_reverse =
+-- >   xs <- given $ Gen.list (Range.linear 0 100) (Gen.enum 'a' 'z')
+-- >   reverse (reverse xs) === xs
+--
+-- And add the Template Haskell splice which will run your properies:
+--
+-- > tests :: IO Bool
+-- > tests =
+-- >   $$(checkAll)
+--
+-- You can then load the module in GHCi, and run it:
+--
+-- >>> tests
+-- ━━━ Test.Example ━━━
+--   ✓ prop_reverse passed 100 tests.
+--
+module Hedgehog (
+    Property
+  , Gen
+  , Range
+  , Seed(..)
+  , Size(..)
+
+  -- * Construction
+  , given
+  , info
+  , success
+  , discard
+  , failure
+  , assert
+  , (===)
+
+  -- * Validation
+  , check
+  , checkAll
+  , recheck
+  ) where
+
+import           Hedgehog.Gen (Gen)
+import           Hedgehog.Internal.Seed (Seed(..))
+import           Hedgehog.Property (assert, (===))
+import           Hedgehog.Property (discard, failure, success)
+import           Hedgehog.Property (given, info)
+import           Hedgehog.Property (Property)
+import           Hedgehog.Range (Range, Size(..))
+import           Hedgehog.Runner (check, recheck)
+import           Hedgehog.TH (checkAll)

--- a/hedgehog/src/Hedgehog/Property.hs
+++ b/hedgehog/src/Hedgehog/Property.hs
@@ -8,12 +8,12 @@ module Hedgehog.Property (
     Property(..)
   , Log(..)
   , Failure(..)
-  , forAll
+  , given
   , info
   , discard
   , failure
   , success
-  , ensure
+  , assert
   , (===)
 
   -- * Internal
@@ -88,8 +88,8 @@ writeLog :: Monad m => Log -> Property m ()
 writeLog =
   Property . lift . tell . pure
 
-forAll :: (Monad m, Show a, Typeable a, HasCallStack) => Gen m a -> Property m a
-forAll gen = do
+given :: (Monad m, Show a, Typeable a, HasCallStack) => Gen m a -> Property m a
+given gen = do
   x <- Property . lift $ lift gen
   writeLog $ Input (getCaller callStack) (typeOf x) (ppShow x)
   return x
@@ -110,8 +110,8 @@ success :: Monad m => Property m ()
 success =
   Property $ pure ()
 
-ensure :: (Monad m, HasCallStack) => Bool -> Property m ()
-ensure b =
+assert :: (Monad m, HasCallStack) => Bool -> Property m ()
+assert b =
   if b then
     success
   else do


### PR DESCRIPTION
This adds a top level module so people don't need to hunt for imports, it also has some placeholder doc which I will elaborate on before release.

I've also twiddled the names, gone from `ensure` back to `assert` and `forAll` is now `given`. I'd be interested in any feedback on this. I'm not particularly concerned with being familiar to QuickCheck users anymore given how different this library is now, so I'm mainly interested in how you think properties read using these names for things.