### PR TITLE
Churn

### DIFF
--- a/hedgehog-example/test/Test/Example/Basic.hs
+++ b/hedgehog-example/test/Test/Example/Basic.hs
@@ -37,8 +37,8 @@ prop_commented_out_properties_do_not_run =
 -- Try 'check prop_foo' to see what happens
 prop_foo :: Monad m => Property m ()
 prop_foo = do
-  x <- given $ Gen.enum 'a' 'z'
-  y <- given $
+  x <- forAll $ Gen.enum 'a' 'z'
+  y <- forAll $
     Gen.choice [
         Gen.integral (Range.linear 0 1000)
       , Gen.integral (Range.linear 0 1000)
@@ -122,8 +122,8 @@ order gen =
 --
 prop_total :: Monad m => Property m ()
 prop_total = do
-  x <- given (order $ Gen.choice [cheap, expensive])
-  y <- given (order expensive)
+  x <- forAll (order $ Gen.choice [cheap, expensive])
+  y <- forAll (order expensive)
   total (merge x y) === total x + total y
 
 ------------------------------------------------------------------------
@@ -159,7 +159,7 @@ genExp =
 
 prop_hutton :: Monad m => Property m ()
 prop_hutton = do
-  x <- given genExp
+  x <- forAll genExp
   case x of
     Add (Add _ _) _ ->
       assert (evalExp x < 100)

--- a/hedgehog/src/Hedgehog.hs
+++ b/hedgehog/src/Hedgehog.hs
@@ -39,7 +39,7 @@ module Hedgehog (
   , Size(..)
 
   -- * Construction
-  , given
+  , forAll
   , info
   , success
   , discard
@@ -57,7 +57,7 @@ import           Hedgehog.Gen (Gen)
 import           Hedgehog.Internal.Seed (Seed(..))
 import           Hedgehog.Property (assert, (===))
 import           Hedgehog.Property (discard, failure, success)
-import           Hedgehog.Property (given, info)
+import           Hedgehog.Property (forAll, info)
 import           Hedgehog.Property (Property)
 import           Hedgehog.Range (Range, Size(..))
 import           Hedgehog.Runner (check, recheck)

--- a/hedgehog/src/Hedgehog/Gen.hs
+++ b/hedgehog/src/Hedgehog/Gen.hs
@@ -623,29 +623,28 @@ bool_ =
 ------------------------------------------------------------------------
 -- Combinators - Strings
 
--- | Generates a random string containing any unicode codepoint.
+-- | Generates a string using 'Range' to determine the length.
 --
-string :: Monad m => Range Int -> Gen m String
-string range =
-  choice [
-       list range (enum 'a' 'z')
-     , list range enumBounded
-     ]
-
--- | Generates a random string containing any unicode codepoint.
+--   /This is a specialization of 'list', offered for convenience./
 --
-text :: Monad m => Range Int -> Gen m Text
-text =
-  fmap Text.pack . string
+string :: Monad m => Range Int -> Gen m Char -> Gen m String
+string =
+  list
 
--- | Generates a random string containing any unicode codepoint, encoded as
---   UTF-8.
+-- | Generates a string using 'Range' to determine the length.
 --
-utf8 :: Monad m => Range Int -> Gen m ByteString
-utf8 =
-  fmap Text.encodeUtf8 . text
+text :: Monad m => Range Int -> Gen m Char -> Gen m Text
+text range =
+  fmap Text.pack . string range
 
--- | Generates a completely random bytes.
+-- | Generates a UTF-8 encoded string, using 'Range' to determine the length.
+--
+utf8 :: Monad m => Range Int -> Gen m Char -> Gen m ByteString
+utf8 range =
+  fmap Text.encodeUtf8 . text range
+
+-- | Generates a random 'ByteString', using 'Range' to determine the
+--   length.
 --
 bytes :: Monad m => Range Int -> Gen m ByteString
 bytes range =

--- a/hedgehog/src/Hedgehog/Property.hs
+++ b/hedgehog/src/Hedgehog/Property.hs
@@ -12,7 +12,7 @@ module Hedgehog.Property (
     Property(..)
   , Log(..)
   , Failure(..)
-  , given
+  , forAll
   , info
   , discard
   , failure
@@ -153,8 +153,8 @@ writeLog :: Monad m => Log -> Property m ()
 writeLog =
   Property . lift . tell . pure
 
-given :: (Monad m, Show a, Typeable a, HasCallStack) => Gen m a -> Property m a
-given gen = do
+forAll :: (Monad m, Show a, Typeable a, HasCallStack) => Gen m a -> Property m a
+forAll gen = do
   x <- Property . lift $ lift gen
   writeLog $ Input (getCaller callStack) (typeOf x) (ppShow x)
   return x


### PR DESCRIPTION
`given` back to `forAll`

Tweaked the string combinators after I tried to use them last night, maybe it would be nice to have `Gen.alpha`, `Gen.upper`, `Gen.lower`, `Gen.digit` for chars