### PR TITLE
Show current test status while running/shrinking

### DIFF
--- a/hedgehog-example/test/Test/Example/Basic.hs
+++ b/hedgehog-example/test/Test/Example/Basic.hs
@@ -36,12 +36,12 @@ prop_commented_out_properties_do_not_run =
 
 prop_test_limit :: Property
 prop_test_limit =
-  withTests 10000 . property $ do
+  withTests 10000 . property $
     success
 
 prop_discard_limit :: Property
 prop_discard_limit =
-  withDiscards 5000 . property $ do
+  withDiscards 5000 . property $
     discard
 
 prop_shrink_limit :: Property

--- a/hedgehog-example/test/Test/Example/STLC.hs
+++ b/hedgehog-example/test/Test/Example/STLC.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DoAndIfThenElse #-}
-{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 module Test.Example.STLC where
@@ -9,7 +8,6 @@ import           Control.Monad
 import           Control.Monad.Morph
 import           Control.Monad.Reader
 
-import           Data.Either
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe
@@ -21,9 +19,6 @@ import           Data.Text (Text)
 import           Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
-
-import           Prelude
-
 
 -- -----------------------------------------------------------------------------
 -- A simply-typed lambda calculus with ints, bools, and strings

--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -41,7 +41,9 @@ library
       base                            >= 3          && < 5
     , ansi-terminal                   >= 0.6        && < 0.7
     , bytestring                      >= 0.10       && < 0.11
+    , concurrent-output               >= 1.7        && < 1.8
     , containers                      >= 0.4        && < 0.6
+    , directory                       >= 1.2        && < 1.4
     , exceptions                      >= 0.7        && < 0.9
     , mmorph                          >= 1.0        && < 1.1
     , mtl                             >= 2.1        && < 2.3

--- a/hedgehog/src/Hedgehog/Gen.hs
+++ b/hedgehog/src/Hedgehog/Gen.hs
@@ -296,12 +296,12 @@ instance MFunctor Gen where
     mapGen (hoist (hoist f))
 
 embedMaybe ::
-  MonadTrans t =>
-  Monad n =>
-  Monad (t (MaybeT n)) =>
-  (forall a. m a -> t (MaybeT n) a) ->
-  MaybeT m b ->
-  t (MaybeT n) b
+     MonadTrans t
+  => Monad n
+  => Monad (t (MaybeT n))
+  => (forall a. m a -> t (MaybeT n) a)
+  -> MaybeT m b
+  -> t (MaybeT n) b
 embedMaybe f m =
   lift . MaybeT . pure =<< f (runMaybeT m)
 

--- a/hedgehog/src/Hedgehog/Internal/Report.hs
+++ b/hedgehog/src/Hedgehog/Internal/Report.hs
@@ -197,14 +197,14 @@ takeInfo = \case
     Nothing
 
 mkFailure ::
-  Size ->
-  Seed ->
-  ShrinkCount ->
-  Maybe Span ->
-  String ->
-  Maybe Diff ->
-  [Log] ->
-  FailureReport
+     Size
+  -> Seed
+  -> ShrinkCount
+  -> Maybe Span
+  -> String
+  -> Maybe Diff
+  -> [Log]
+  -> FailureReport
 mkFailure size seed shrinks location message diff logs =
   let
     inputs =
@@ -343,9 +343,9 @@ ppFailedInputTypedArgument ix (FailedInput _ typ val) =
     ]
 
 ppFailedInputDeclaration ::
-  MonadIO m =>
-  FailedInput ->
-  m (Maybe (Declaration (Style, [(Style, Doc Markup)])))
+     MonadIO m
+  => FailedInput
+  -> m (Maybe (Declaration (Style, [(Style, Doc Markup)])))
 ppFailedInputDeclaration (FailedInput msloc _ val) =
   runMaybeT $ do
     sloc <- MaybeT $ pure msloc
@@ -379,10 +379,10 @@ ppFailedInputDeclaration (FailedInput msloc _ val) =
       mapSource (styleInput . insertDoc) decl
 
 ppFailedInput ::
-  MonadIO m =>
-  Int ->
-  FailedInput ->
-  m (Either (Doc Markup) (Declaration (Style, [(Style, Doc Markup)])))
+     MonadIO m
+  => Int
+  -> FailedInput
+  -> m (Either (Doc Markup) (Declaration (Style, [(Style, Doc Markup)])))
 ppFailedInput ix input = do
   mdecl <- ppFailedInputDeclaration input
   case mdecl of
@@ -415,11 +415,11 @@ ppDiff (Diff removed op added diff) = [
   ] ++ fmap ppLineDiff (toLineDiff diff)
 
 ppFailureLocation ::
-  MonadIO m =>
-  String ->
-  Maybe Diff ->
-  Span ->
-  m (Maybe (Declaration (Style, [(Style, Doc Markup)])))
+     MonadIO m
+  => String
+  -> Maybe Diff
+  -> Span
+  -> m (Maybe (Declaration (Style, [(Style, Doc Markup)])))
 ppFailureLocation msg mdiff sloc =
   runMaybeT $ do
     decl <- fmap defaultStyle . MaybeT $ readDeclaration sloc

--- a/hedgehog/src/Hedgehog/Internal/Runner.hs
+++ b/hedgehog/src/Hedgehog/Internal/Runner.hs
@@ -10,6 +10,7 @@ module Hedgehog.Internal.Runner (
 
   -- * Internal
   , checkReport
+  , checkConsole
   ) where
 
 import           Control.Monad.Catch (MonadCatch(..), catchAll)
@@ -25,6 +26,9 @@ import           Hedgehog.Internal.Property (Test, Log(..), Failure(..), runTest
 import           Hedgehog.Internal.Property (Property(..), Config(..))
 import           Hedgehog.Internal.Property (ShrinkLimit, withTests)
 import           Hedgehog.Range (Size)
+
+import           System.Console.Regions (RegionLayout(..))
+import qualified System.Console.Regions as Console
 
 ------------------------------------------------------------------------
 
@@ -54,29 +58,32 @@ takeSmallest ::
   -> Seed
   -> ShrinkCount
   -> ShrinkLimit
+  -> (Status -> m ())
   -> Node m (Maybe (Either Failure (), [Log]))
   -> m Status
-takeSmallest size seed shrinks slimit = \case
+takeSmallest size seed shrinks slimit updateUI = \case
   Node Nothing _ ->
     pure GaveUp
 
   Node (Just (x, w)) xs ->
     case x of
-      Left (Failure loc err mdiff) ->
+      Left (Failure loc err mdiff) -> do
         let
-          status =
-            Failed $ mkFailure size seed shrinks loc err mdiff w
-        in
-          if shrinks >= fromIntegral slimit then
-            -- if we've hit the shrink limit, don't shrink any further
-            pure status
-          else
-            findM xs status $ \m -> do
-              o <- runTree m
-              if isFailure o then
-                Just <$> takeSmallest size seed (shrinks + 1) slimit o
-              else
-                return Nothing
+          failure =
+            mkFailure size seed shrinks loc err mdiff w
+
+        updateUI $ Shrinking failure
+
+        if shrinks >= fromIntegral slimit then
+          -- if we've hit the shrink limit, don't shrink any further
+          pure $ Failed failure
+        else
+          findM xs (Failed failure) $ \m -> do
+            o <- runTree m
+            if isFailure o then
+              Just <$> takeSmallest size seed (shrinks + 1) slimit updateUI o
+            else
+              return Nothing
 
       Right () ->
         return OK
@@ -89,14 +96,17 @@ checkReport ::
   -> Size
   -> Seed
   -> Test m ()
+  -> (Report -> m ())
   -> m Report
-checkReport cfg size0 seed0 test0 =
+checkReport cfg size0 seed0 test0 updateUI =
   let
     test =
       catchAll test0 (fail . show)
 
     loop :: TestCount -> DiscardCount -> Size -> Seed -> m Report
-    loop !tests !discards !size !seed =
+    loop !tests !discards !size !seed = do
+      updateUI $ Report tests discards Running
+
       if size > 99 then
         -- size has reached limit, reset to 0
         loop tests discards 0 seed
@@ -119,19 +129,38 @@ checkReport cfg size0 seed0 test0 =
                 loop tests (discards + 1) (size + 1) s1
 
               Just (Left _, _) ->
-                Report (tests + 1) discards
-                  <$> takeSmallest size seed 0 (configShrinkLimit cfg) node
+                let
+                  mkReport =
+                    Report (tests + 1) discards
+                in
+                  fmap mkReport $
+                    takeSmallest
+                      size
+                      seed
+                      0
+                      (configShrinkLimit cfg)
+                      (updateUI . mkReport)
+                      node
 
               Just (Right (), _) ->
                 loop (tests + 1) discards (size + 1) s1
   in
     loop 0 0 size0 seed0
 
+checkConsole :: MonadIO m => Maybe String -> Size -> Seed -> Property -> m Report
+checkConsole name size seed prop =
+  liftIO .
+  Console.displayConsoleRegions .
+  Console.withConsoleRegion Linear $ \region -> do
+    checkReport (propertyConfig prop) size seed (propertyTest prop) $ \report -> do
+      x <- renderReport name report
+      Console.setConsoleRegion region x
+
 checkNamed :: MonadIO m => Maybe String -> Property -> m Bool
 checkNamed name prop = do
   seed <- liftIO Seed.random
-  report <- liftIO $ checkReport (propertyConfig prop) 0 seed (propertyTest prop)
-  printReport name report
+  report <- checkConsole name 0 seed prop
+  liftIO . putStrLn =<< renderReport name report
   pure $
     reportStatus report == OK
 
@@ -146,5 +175,5 @@ check =
 recheck :: MonadIO m => Size -> Seed -> Property -> m ()
 recheck size seed prop0 = do
   let prop = withTests 1 prop0
-  report <- liftIO $ checkReport (propertyConfig prop) size seed (propertyTest prop)
-  printReport Nothing report
+  report <- checkConsole Nothing size seed prop
+  liftIO . putStrLn =<< renderReport Nothing report

--- a/hedgehog/src/Hedgehog/Internal/Runner.hs
+++ b/hedgehog/src/Hedgehog/Internal/Runner.hs
@@ -49,13 +49,13 @@ isFailure = \case
     False
 
 takeSmallest ::
-  MonadIO m =>
-  Size ->
-  Seed ->
-  ShrinkCount ->
-  ShrinkLimit ->
-  Node m (Maybe (Either Failure (), [Log])) ->
-  m Status
+     MonadIO m
+  => Size
+  -> Seed
+  -> ShrinkCount
+  -> ShrinkLimit
+  -> Node m (Maybe (Either Failure (), [Log]))
+  -> m Status
 takeSmallest size seed shrinks slimit = \case
   Node Nothing _ ->
     pure GaveUp
@@ -82,14 +82,14 @@ takeSmallest size seed shrinks slimit = \case
         return OK
 
 checkReport ::
-  forall m.
-  MonadIO m =>
-  MonadCatch m =>
-  Config ->
-  Size ->
-  Seed ->
-  Test m () ->
-  m Report
+     forall m.
+     MonadIO m
+  => MonadCatch m
+  => Config
+  -> Size
+  -> Seed
+  -> Test m ()
+  -> m Report
 checkReport cfg size0 seed0 test0 =
   let
     test =

--- a/hedgehog/src/Hedgehog/Internal/Show.hs
+++ b/hedgehog/src/Hedgehog/Internal/Show.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PatternGuards #-}
 module Hedgehog.Internal.Show (
     Name
   , Value(..)


### PR DESCRIPTION
This was one of the last things left to do before a Hackage release, the test runner now shows the current status of a test while it is running/shrinking:
<img width="328" alt="screen shot 2017-04-08 at 9 28 09 am" src="https://cloud.githubusercontent.com/assets/134805/24823243/97a77aa2-1c3f-11e7-9d74-12cbc0cc54bd.png">
<img width="470" alt="screen shot 2017-04-08 at 9 20 18 am" src="https://cloud.githubusercontent.com/assets/134805/24823227/79d26316-1c3f-11e7-927f-f9f8d2ccafd0.png">

