### PR TITLE
Runner: Add checkReportNoCatch

### DIFF
--- a/hedgehog/src/Hedgehog/Internal/Runner.hs
+++ b/hedgehog/src/Hedgehog/Internal/Runner.hs
@@ -12,6 +12,7 @@ module Hedgehog.Internal.Runner (
 
   -- * Internal
   , checkReport
+  , checkReportNoCatch
   , checkConsoleRegion
   , checkNamed
   ) where
@@ -126,11 +127,20 @@ checkReport ::
   -> Test m ()
   -> (Report -> m ())
   -> m Report
-checkReport cfg size0 seed0 test0 updateUI =
-  let
-    test =
-      catchAll test0 (fail . show)
+checkReport cfg size0 seed0 test updateUI =
+  checkReportNoCatch cfg size0 seed0 (catchAll test (fail . show)) updateUI
 
+checkReportNoCatch ::
+     forall m.
+     MonadIO m
+  => PropertyConfig
+  -> Size
+  -> Seed
+  -> Test m ()
+  -> (Report -> m ())
+  -> m Report
+checkReportNoCatch cfg size0 seed0 test updateUI =
+  let
     loop :: TestCount -> DiscardCount -> Size -> Seed -> m Report
     loop !tests !discards !size !seed = do
       updateUI $ Report tests discards Running


### PR DESCRIPTION
Need this for Hspec integration. Hspec has the ability to check that
the correct exception gets thrown from a test and hence needs the
exception to escape the test runner.