### PR TITLE
Make it easier to use Hedgehog without Template Haskell

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-hedgehog [![Hackage version](https://img.shields.io/hackage/v/hedgehog.svg?style=flat)](http://hackage.haskell.org/package/hedgehog) [![Build Status](https://travis-ci.org/hedgehogqa/haskell-hedgehog.svg?branch=master)](https://travis-ci.org/hedgehogqa/haskell-hedgehog)
+hedgehog [![Hackage][hackage-shield]][hackage] [![Travis][travis-shield]][travis]
 ========
 
 > Hedgehog will eat all your bugs.
@@ -16,3 +16,69 @@ so shrinks obey the invariants of generated values by construction.
 - Range combinators for full control over the scope of generated numbers and collections.
 - Equality and roundtrip assertions show a diff instead of the two inequal values.
 - Template Haskell test runner which executes properties concurrently.
+
+## Example
+
+The main module, [Hedgehog][haddock-hedgehog], includes almost
+everything you need to get started writing property tests with Hedgehog.
+
+It is designed to be used alongside [Hedgehog.Gen][haddock-hedgehog-gen]
+and [Hedgehog.Range][haddock-hedgehog-range] which should be imported
+qualified. You also need to enable Template Haskell so the Hedgehog test
+runner can find your properties.
+
+```hs
+{-# LANGUAGE TemplateHaskell #-}
+
+import           Hedgehog
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+```
+
+Once you have your imports set up, you can write a simple property:
+
+```hs
+prop_reverse :: Property
+prop_reverse =
+  property $ do
+    xs <- forAll $ Gen.list (Range.linear 0 100) Gen.alpha
+    reverse (reverse xs) === xs
+```
+
+And add the Template Haskell splice which will discover your properties:
+
+```hs
+tests :: IO Bool
+tests =
+  checkConcurrent $$(discover)
+```
+
+If you prefer to avoid macros, you can specify the group of properties
+to run manually instead:
+
+```hs
+tests :: IO Bool
+tests =
+  checkConcurrent $ Group "Test.Example" [
+      ("prop_reverse", prop_reverse)
+    ]
+```
+
+You can then load the module in GHCi, and run it:
+
+```
+λ tests
+━━━ Test.Example ━━━
+  ✓ prop_reverse passed 100 tests.
+
+```
+
+ [hackage]: http://hackage.haskell.org/package/hedgehog
+ [hackage-shield]: http://img.shields.io/hackage/v/hedgehog.svg?style=flat
+
+ [travis]: https://travis-ci.org/hedgehogqa/haskell-hedgehog
+ [travis-shield]: https://travis-ci.org/hedgehogqa/haskell-hedgehog.svg?branch=master
+
+ [haddock-hedgehog]: http://hackage.haskell.org/package/hedgehog/docs/Hedgehog.html
+ [haddock-hedgehog-gen]: http://hackage.haskell.org/package/hedgehog/docs/Hedgehog-Gen.html
+ [haddock-hedgehog-range]: http://hackage.haskell.org/package/hedgehog/docs/Hedgehog-Range.html

--- a/hedgehog-example/test/Test/Example/Basic.hs
+++ b/hedgehog-example/test/Test/Example/Basic.hs
@@ -254,4 +254,4 @@ prop_record =
 
 tests :: IO Bool
 tests =
-  $$(checkSequential)
+  checkSequential $$(discover)

--- a/hedgehog-example/test/Test/Example/Resource.hs
+++ b/hedgehog-example/test/Test/Example/Resource.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 module Test.Example.Resource where
 
@@ -55,4 +56,6 @@ prop_unix_sort =
 
 tests :: IO Bool
 tests =
-  $$(checkSequential)
+  checkSequential $ Group "Test.Example.Resource" [
+      ("prop_unix_sort", prop_unix_sort)
+    ]

--- a/hedgehog-example/test/Test/Example/STLC.hs
+++ b/hedgehog-example/test/Test/Example/STLC.hs
@@ -331,4 +331,4 @@ prop_idempotent6 =
 
 tests :: IO Bool
 tests =
-  $$(checkConcurrent)
+  checkConcurrent $$(discover)

--- a/hedgehog/src/Hedgehog.hs
+++ b/hedgehog/src/Hedgehog.hs
@@ -20,11 +20,20 @@
 -- >     xs <- forAll $ Gen.list (Range.linear 0 100) Gen.alpha
 -- >     reverse (reverse xs) === xs
 --
--- And add the Template Haskell splice which will run your properties:
+-- And add the Template Haskell splice which will discover your properties:
 --
 -- > tests :: IO Bool
 -- > tests =
--- >   $$(checkConcurrent)
+-- >   checkConcurrent $$(discover)
+--
+-- If you prefer to avoid macros, you can specify the group of properties to
+-- run manually instead:
+--
+-- > tests :: IO Bool
+-- > tests =
+-- >   checkConcurrent $ Group "Test.Example" [
+-- >       ("prop_reverse", prop_reverse)
+-- >     ]
 --
 -- You can then load the module in GHCi, and run it:
 --
@@ -33,7 +42,8 @@
 --   ✓ prop_reverse passed 100 tests.
 --
 module Hedgehog (
-    Property
+    Group(..)
+  , Property
   , Test
   , TestLimit
   , DiscardLimit
@@ -51,9 +61,11 @@ module Hedgehog (
   , withShrinks
 
   , check
-  , checkSequential
-  , checkConcurrent
   , recheck
+
+  , discover
+  , checkConcurrent
+  , checkSequential
 
   -- * Test
   , forAll
@@ -77,12 +89,12 @@ import           Hedgehog.Internal.Property (discard, failure, success)
 import           Hedgehog.Internal.Property (DiscardLimit, withDiscards)
 import           Hedgehog.Internal.Property (forAll, info)
 import           Hedgehog.Internal.Property (liftEither, liftExceptT, withResourceT)
-import           Hedgehog.Internal.Property (Property)
+import           Hedgehog.Internal.Property (Property, Group(..))
 import           Hedgehog.Internal.Property (ShrinkLimit, withShrinks)
 import           Hedgehog.Internal.Property (Test, property)
 import           Hedgehog.Internal.Property (TestLimit, withTests)
-import           Hedgehog.Internal.Runner (check, recheck)
+import           Hedgehog.Internal.Runner (check, recheck, checkSequential, checkConcurrent)
 import           Hedgehog.Internal.Seed (Seed(..))
-import           Hedgehog.Internal.TH (checkSequential, checkConcurrent)
+import           Hedgehog.Internal.TH (discover)
 import           Hedgehog.Internal.Tripping (tripping)
 import           Hedgehog.Range (Range, Size(..))

--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -15,7 +15,6 @@
 module Hedgehog.Internal.Property (
   -- * Property
     Property(..)
-  , GroupName(..)
   , PropertyName(..)
   , PropertyConfig(..)
   , TestLimit(..)
@@ -25,6 +24,10 @@ module Hedgehog.Internal.Property (
   , withTests
   , withDiscards
   , withShrinks
+
+  -- * Group
+  , Group(..)
+  , GroupName(..)
 
   -- * Test
   , Test(..)
@@ -69,6 +72,7 @@ import           Control.Monad.Trans.Resource (ResourceT, runResourceT)
 import           Control.Monad.Trans.Writer.Lazy (WriterT(..))
 import           Control.Monad.Writer.Class (MonadWriter(..))
 
+import           Data.String (IsString)
 import           Data.Typeable (Typeable, TypeRep, typeOf)
 
 import           Hedgehog.Gen (Gen)
@@ -96,19 +100,12 @@ newtype Test m a =
       unTest :: ExceptT Failure (WriterT [Log] (Gen m)) a
     } deriving (Functor, Applicative)
 
--- | The name of a group of properties.
---
-newtype GroupName =
-  GroupName {
-      unGroupName :: String
-    } deriving (Eq, Ord, Show)
-
 -- | The name of a property.
 --
 newtype PropertyName =
   PropertyName {
       unPropertyName :: String
-    } deriving (Eq, Ord, Show)
+    } deriving (Eq, Ord, Show, IsString)
 
 -- | Configuration for a property test.
 --
@@ -137,6 +134,21 @@ newtype ShrinkLimit =
 newtype DiscardLimit =
   DiscardLimit Int
   deriving (Eq, Ord, Show, Num, Enum, Real, Integral)
+
+-- | A named collection of property tests.
+--
+data Group =
+  Group {
+      groupName :: !GroupName
+    , groupProperties :: ![(PropertyName, Property)]
+    }
+
+-- | The name of a group of properties.
+--
+newtype GroupName =
+  GroupName {
+      unGroupName :: String
+    } deriving (Eq, Ord, Show, IsString)
 
 --
 -- FIXME This whole Log/Failure thing could be a lot more structured to allow

--- a/hedgehog/test/Test/Hedgehog/Text.hs
+++ b/hedgehog/test/Test/Hedgehog/Text.hs
@@ -73,4 +73,4 @@ prop_tripping_append_seed =
 
 tests :: IO Bool
 tests =
-  $$(checkConcurrent)
+  checkConcurrent $$(discover)


### PR DESCRIPTION
This adds a type `Group` which is a named collection of properties.

`checkConcurrent` and `checkSequential` are now regular functions which can execute the property tests in a `Group`. The Template Haskell property discovery is now just a single function `discover` which returns a `Group`.

Running tests with automatic discovery now looks like this:

```hs
tests :: IO Bool
tests =
  checkConcurrent $$(discover)
```

But now, if you prefer to avoid macros, you can specify the group of properties to run manually instead:

```hs
tests :: IO Bool
tests =
  checkConcurrent $ Group "Test.Example" [
      ("prop_reverse", prop_reverse)
    ]
```