### PR TITLE
add Gen.constant

### DIFF
--- a/hedgehog/src/Hedgehog/Gen.hs
+++ b/hedgehog/src/Hedgehog/Gen.hs
@@ -74,6 +74,7 @@ module Hedgehog.Gen (
   , bytes
 
   -- ** Choice
+  , constant
   , element
   , choice
   , frequency
@@ -767,6 +768,13 @@ bytes range =
 
 ------------------------------------------------------------------------
 -- Combinators - Choice
+
+-- | Trivial generator that always produces the same element.
+--
+--   /This is another name for 'pure' \/ 'return'./
+constant :: Monad m => a -> Gen m a
+constant =
+  pure
 
 -- | Randomly selects one of the elements in the list.
 --


### PR DESCRIPTION
I spent a while looking for this function, and eventually found #34 and felt silly when I realized you can just use `pure` for this. So I figured since at least two of us have made this mistake so far, it'd be good to leave some kind of reminder in the documentation.

I propose adding an alias called `constant`, with a note explaining that it is equivalent to `pure`.

It didn't quite fit neatly into any of the sections, but I put it under "Choice" because you can think of it as a specialization of `element` with a single value, which I also point out in the documentation.