### PR TITLE
Make the examples runnable with doctest

### DIFF
--- a/hedgehog/src/Hedgehog/Internal/Shrink.hs
+++ b/hedgehog/src/Hedgehog/Internal/Shrink.hs
@@ -37,11 +37,11 @@ towards destination x =
 
 -- | Shrink a floating-point number by edging towards a destination.
 --
---   >>> towards 0.0 100
---   [0.0,50.0,75.0,87.5,93.75,96.875,98.4375,..
+--   >>> take 7 (towardsFloat 0.0 100)
+--   [0.0,50.0,75.0,87.5,93.75,96.875,98.4375]
 --
---   >>> towards 1.0 0.5
---   [1.0,0.75,0.625,0.5625,0.53125,0.515625,0.5078125,..
+--   >>> take 7 (towardsFloat 1.0 0.5)
+--   [1.0,0.75,0.625,0.5625,0.53125,0.515625,0.5078125]
 --
 --   /Note we always try the destination first, as that is the optimal shrink./
 --

--- a/hedgehog/src/Hedgehog/Range.hs
+++ b/hedgehog/src/Hedgehog/Range.hs
@@ -34,6 +34,10 @@ import           Data.Bifunctor (bimap)
 
 import           Prelude hiding (minimum, maximum)
 
+-- $setup
+-- >>> import Data.Int (Int8)
+-- >>> let x = 3
+
 -- | Tests are parameterized by the size of the randomly-generated data, the
 --   meaning of which depends on the particular generator used.
 --


### PR DESCRIPTION
With these couple of tweaks, the code examples can be made runnable with [doctest](https://hackage.haskell.org/package/doctest).

```bash
> doctest hedgehog/src/Hedgehog
Examples: 34  Tried: 34  Errors: 0  Failures: 0
```

This PR also fixes an error in one of the examples, a `towards` that should be `towardsFloat` (a problem that I found by running doctest :smile:)