### PR TITLE
Expose GroupName and PropertyName

### DIFF
--- a/hedgehog/src/Hedgehog.hs
+++ b/hedgehog/src/Hedgehog.hs
@@ -43,7 +43,9 @@
 --
 module Hedgehog (
     Group(..)
+  , GroupName
   , Property
+  , PropertyName
   , Test
   , TestLimit
   , DiscardLimit
@@ -89,7 +91,7 @@ import           Hedgehog.Internal.Property (discard, failure, success)
 import           Hedgehog.Internal.Property (DiscardLimit, withDiscards)
 import           Hedgehog.Internal.Property (forAll, info)
 import           Hedgehog.Internal.Property (liftEither, liftExceptT, withResourceT)
-import           Hedgehog.Internal.Property (Property, Group(..))
+import           Hedgehog.Internal.Property (Property, PropertyName, Group(..), GroupName)
 import           Hedgehog.Internal.Property (ShrinkLimit, withShrinks)
 import           Hedgehog.Internal.Property (Test, property)
 import           Hedgehog.Internal.Property (TestLimit, withTests)

--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -72,6 +72,7 @@ import           Control.Monad.Trans.Resource (ResourceT, runResourceT)
 import           Control.Monad.Trans.Writer.Lazy (WriterT(..))
 import           Control.Monad.Writer.Class (MonadWriter(..))
 
+import           Data.Semigroup (Semigroup)
 import           Data.String (IsString)
 import           Data.Typeable (Typeable, TypeRep, typeOf)
 
@@ -105,7 +106,7 @@ newtype Test m a =
 newtype PropertyName =
   PropertyName {
       unPropertyName :: String
-    } deriving (Eq, Ord, Show, IsString)
+    } deriving (Eq, Ord, Show, IsString, Semigroup)
 
 -- | Configuration for a property test.
 --
@@ -148,7 +149,7 @@ data Group =
 newtype GroupName =
   GroupName {
       unGroupName :: String
-    } deriving (Eq, Ord, Show, IsString)
+    } deriving (Eq, Ord, Show, IsString, Semigroup)
 
 --
 -- FIXME This whole Log/Failure thing could be a lot more structured to allow


### PR DESCRIPTION
This adds `GroupName` and `PropertyName` to the `Hedgehog` module; these types are important to have when you're constructing groups explicitly instead of using TH.

I also added `Semigroup` instances because I found myself wanting to append text onto property names.