### PR TITLE
Concurrent runner doesn't display tests which aren't running

### DIFF
--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -59,6 +59,7 @@ library
     , primitive                       >= 0.6        && < 0.7
     , random                          >= 1.1        && < 1.2
     , resourcet                       >= 1.1        && < 1.2
+    , stm                             >= 2.4        && < 2.5
     , template-haskell                >= 2.10       && < 2.12
     , text                            >= 1.1        && < 1.3
     , th-lift                         >= 0.7        && < 0.8


### PR DESCRIPTION
If you had a large number of tests before, the default concurrent runner could end up off the screen. Now we only show tests that are running or have been run, with just a single line dedicated to the tests which are yet to come.

<img width="338" alt="screen shot 2017-04-17 at 7 03 49 pm" src="https://cloud.githubusercontent.com/assets/134805/25084650/1061419a-23a1-11e7-944f-3de86e6b74b5.png">

This should partially address https://github.com/hedgehogqa/haskell-hedgehog/issues/51

The next thing is to add a quiet mode which users can configure if they prefer, which just displays the number of tests passed at the end of the execution, and any failures which occurred. This may even be preferable on CI servers, even though the current system does handle non-tty stdout correctly.