### PR TITLE
Add quiet test runner

### DIFF
--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -87,8 +87,11 @@ library
     Hedgehog.Gen
     Hedgehog.Range
 
+    Hedgehog.Internal.Config
     Hedgehog.Internal.Discovery
     Hedgehog.Internal.Property
+    Hedgehog.Internal.Queue
+    Hedgehog.Internal.Region
     Hedgehog.Internal.Report
     Hedgehog.Internal.Runner
     Hedgehog.Internal.Seed

--- a/hedgehog/src/Hedgehog/Internal/Config.hs
+++ b/hedgehog/src/Hedgehog/Internal/Config.hs
@@ -1,0 +1,171 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DoAndIfThenElse #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Hedgehog.Internal.Config (
+    UseColor(..)
+  , resolveColor
+
+  , Verbosity(..)
+  , resolveVerbosity
+
+  , WorkerCount(..)
+  , resolveWorkers
+
+  , detectMark
+  , detectColor
+  , detectVerbosity
+  , detectWorkers
+  ) where
+
+import           Control.Monad.IO.Class (MonadIO(..))
+
+import qualified GHC.Conc as Conc
+
+import           Language.Haskell.TH.Lift (deriveLift)
+
+import           System.Console.ANSI (hSupportsANSI)
+import           System.Environment (lookupEnv)
+import           System.IO (stdout)
+
+#if !mingw32_HOST_OS
+import           System.Posix.User (getEffectiveUserName)
+#endif
+
+import           Text.Read (readMaybe)
+
+
+-- | Whether to render output using ANSI colors or not.
+--
+data UseColor =
+    DisableColor
+    -- ^ Disable ANSI colors in report output.
+  | EnableColor
+    -- ^ Enable ANSI colors in report output.
+    deriving (Eq, Ord, Show)
+
+-- | How verbose should the report output be.
+--
+data Verbosity =
+    Quiet
+    -- ^ Only display the summary of the test run.
+  | Normal
+    -- ^ Display each property as it is running, as well as the summary.
+    deriving (Eq, Ord, Show)
+
+-- | The number of workers to use when running properties in parallel.
+--
+newtype WorkerCount =
+  WorkerCount Int
+  deriving (Eq, Ord, Show, Num, Enum, Real, Integral)
+
+detectMark :: MonadIO m => m Bool
+detectMark = do
+#if mingw32_HOST_OS
+   pure False
+#else
+   user <- liftIO getEffectiveUserName
+   pure $ user == "mth"
+#endif
+
+lookupBool :: MonadIO m => String -> m (Maybe Bool)
+lookupBool key =
+  liftIO $ do
+    menv <- lookupEnv key
+    case menv of
+      Just "0" ->
+        pure $ Just False
+      Just "no" ->
+        pure $ Just False
+      Just "false" ->
+        pure $ Just False
+
+      Just "1" ->
+        pure $ Just True
+      Just "yes" ->
+        pure $ Just True
+      Just "true" ->
+        pure $ Just True
+
+      _ ->
+        pure Nothing
+
+detectColor :: MonadIO m => m UseColor
+detectColor =
+  liftIO $ do
+    ok <- lookupBool "HEDGEHOG_COLOR"
+    case ok of
+      Just False ->
+        pure DisableColor
+
+      Just True ->
+        pure EnableColor
+
+      Nothing -> do
+        mth <- detectMark
+        if mth then
+          pure DisableColor -- avoid getting fired :)
+        else do
+          enable <- hSupportsANSI stdout
+          if enable then
+            pure EnableColor
+          else
+            pure DisableColor
+
+detectVerbosity :: MonadIO m => m Verbosity
+detectVerbosity =
+  liftIO $ do
+    menv <- (readMaybe =<<) <$> lookupEnv "HEDGEHOG_VERBOSITY"
+    case menv of
+      Just (0 :: Int) ->
+        pure Quiet
+
+      Just (1 :: Int) ->
+        pure Normal
+
+      _ -> do
+        mth <- detectMark
+        if mth then
+          pure Quiet
+        else
+          pure Normal
+
+detectWorkers :: MonadIO m => m WorkerCount
+detectWorkers = do
+  liftIO $ do
+    menv <- (readMaybe =<<) <$> lookupEnv "HEDGEHOG_WORKERS"
+    case menv of
+      Nothing ->
+        WorkerCount <$> Conc.getNumProcessors
+      Just env ->
+        pure $ WorkerCount env
+
+resolveColor :: MonadIO m => Maybe UseColor -> m UseColor
+resolveColor = \case
+  Nothing ->
+    detectColor
+  Just x ->
+    pure x
+
+resolveVerbosity :: MonadIO m => Maybe Verbosity -> m Verbosity
+resolveVerbosity = \case
+  Nothing ->
+    detectVerbosity
+  Just x ->
+    pure x
+
+resolveWorkers :: MonadIO m => Maybe WorkerCount -> m WorkerCount
+resolveWorkers = \case
+  Nothing ->
+    detectWorkers
+  Just x ->
+    pure x
+
+------------------------------------------------------------------------
+-- FIXME Replace with DeriveLift when we drop 7.10 support.
+
+$(deriveLift ''UseColor)
+$(deriveLift ''Verbosity)
+$(deriveLift ''WorkerCount)

--- a/hedgehog/src/Hedgehog/Internal/Queue.hs
+++ b/hedgehog/src/Hedgehog/Internal/Queue.hs
@@ -1,0 +1,116 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+module Hedgehog.Internal.Queue (
+    TaskIndex(..)
+  , TasksRemaining(..)
+
+  , runTasks
+  , finalizeTask
+ 
+  , runActiveFinalizers
+  , dequeueMVar
+
+  , updateNumCapabilities
+  ) where
+
+import           Control.Concurrent.Async (forConcurrently)
+import           Control.Concurrent.MVar (MVar)
+import qualified Control.Concurrent.MVar as MVar
+import           Control.Monad (when)
+import           Control.Monad.IO.Class (MonadIO(..))
+
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+
+import qualified GHC.Conc as Conc
+
+import           Hedgehog.Internal.Config
+
+
+newtype TaskIndex =
+  TaskIndex Int
+  deriving (Eq, Ord, Enum, Num)
+
+newtype TasksRemaining =
+  TasksRemaining Int
+
+dequeueMVar ::
+     MVar [(TaskIndex, a)]
+  -> (TasksRemaining -> TaskIndex -> a -> IO b)
+  -> IO (Maybe (TaskIndex, b))
+dequeueMVar mvar start =
+  MVar.modifyMVar mvar $ \case
+    [] ->
+      pure ([], Nothing)
+    (ix, x) : xs -> do
+      y <- start (TasksRemaining $ length xs) ix x
+      pure (xs, Just (ix, y))
+
+runTasks ::
+     WorkerCount
+  -> [a]
+  -> (TasksRemaining -> TaskIndex -> a -> IO b)
+  -> (b -> IO ())
+  -> (b -> IO ())
+  -> (b -> IO c)
+  -> IO [c]
+runTasks n tasks start finish finalize runTask = do
+  qvar <- MVar.newMVar (zip [0..] tasks)
+  fvar <- MVar.newMVar (-1, Map.empty)
+
+  let
+    worker rs = do
+      mx <- dequeueMVar qvar start
+      case mx of
+        Nothing ->
+          pure rs
+        Just (ix, x) -> do
+          r <- runTask x
+          finish x
+          finalizeTask fvar ix (finalize x)
+          worker (r : rs)
+
+  -- FIXME ensure all workers have finished running
+  fmap concat . forConcurrently [1..max 1 n] $ \_ix ->
+    worker []
+
+runActiveFinalizers ::
+     MonadIO m
+  => MVar (TaskIndex, Map TaskIndex (IO ()))
+  -> m ()
+runActiveFinalizers mvar =
+  liftIO $ do
+    again <-
+      MVar.modifyMVar mvar $ \original@(minIx, finalizers0) ->
+        case Map.minViewWithKey finalizers0 of
+          Nothing ->
+            pure (original, False)
+
+          Just ((ix, finalize), finalizers) ->
+            if ix == minIx + 1 then do
+              finalize
+              pure ((ix, finalizers), True)
+            else
+              pure (original, False)
+
+    when again $
+      runActiveFinalizers mvar
+
+finalizeTask ::
+     MonadIO m
+  => MVar (TaskIndex, Map TaskIndex (IO ()))
+  -> TaskIndex
+  -> IO ()
+  -> m ()
+finalizeTask mvar ix finalize = do
+  liftIO . MVar.modifyMVar_ mvar $ \(minIx, finalizers) ->
+    pure (minIx, Map.insert ix finalize finalizers)
+  runActiveFinalizers mvar
+
+-- | Update the number of capabilities but never set it lower than it already
+--   is.
+--
+updateNumCapabilities :: WorkerCount -> IO ()
+updateNumCapabilities (WorkerCount n) = do
+  ncaps <- Conc.getNumCapabilities
+  Conc.setNumCapabilities (max n ncaps)

--- a/hedgehog/src/Hedgehog/Internal/Region.hs
+++ b/hedgehog/src/Hedgehog/Internal/Region.hs
@@ -1,0 +1,110 @@
+module Hedgehog.Internal.Region (
+    Region(..)
+  , newEmptyRegion
+  , newRegion
+  , forceRegion
+  , setRegion
+  , displayRegions
+  , displayRegion
+  , moveToBottom
+  , finishRegion
+  ) where
+
+import           Control.Concurrent.STM (STM, TVar, atomically)
+import qualified Control.Concurrent.STM.TMVar as TMVar
+import qualified Control.Concurrent.STM.TVar as TVar
+import           Control.Monad.Catch (MonadMask(..), bracket)
+import           Control.Monad.IO.Class (MonadIO(..))
+
+import           System.Console.Regions (ConsoleRegion, RegionLayout(..), LiftRegion(..))
+import qualified System.Console.Regions as Console
+
+
+newtype Region =
+  Region {
+      unRegion :: TVar (Maybe ConsoleRegion)
+    }
+
+newEmptyRegion :: LiftRegion m => m Region
+newEmptyRegion =
+  liftRegion $ do
+    ref <- TVar.newTVar Nothing
+    pure $ Region ref
+
+newRegion :: LiftRegion m => m Region
+newRegion =
+  liftRegion $ do
+    region <- Console.openConsoleRegion Linear
+    ref <- TVar.newTVar $ Just region
+    pure $ Region ref
+
+forceRegion :: LiftRegion m => Region -> String -> m ()
+forceRegion (Region var) content =
+  liftRegion $ do
+    mregion <- TVar.readTVar var
+    case mregion of
+      Nothing -> do
+        region <- Console.openConsoleRegion Linear
+        TVar.writeTVar var $ Just region
+        Console.setConsoleRegion region content
+
+      Just region ->
+        Console.setConsoleRegion region content
+
+setRegion :: LiftRegion m => Region -> String -> m ()
+setRegion (Region var) content =
+  liftRegion $ do
+    mregion <- TVar.readTVar var
+    case mregion of
+      Nothing -> do
+        pure ()
+
+      Just region ->
+        Console.setConsoleRegion region content
+
+displayRegions :: (MonadIO m, MonadMask m) => m a -> m a
+displayRegions io = do
+  liftIO . atomically $ do
+    -- clear old regions
+    mxs <- TMVar.tryTakeTMVar Console.regionList
+    case mxs of
+      Nothing ->
+        pure ()
+      Just _xs ->
+        TMVar.putTMVar Console.regionList []
+
+  Console.displayConsoleRegions io
+
+displayRegion ::
+     MonadIO m
+  => MonadMask m
+  => LiftRegion m
+  => (Region -> m a)
+  -> m a
+displayRegion =
+  displayRegions . bracket newRegion finishRegion
+
+moveToBottom :: ConsoleRegion -> STM ()
+moveToBottom region = do
+  mxs <- TMVar.tryTakeTMVar Console.regionList
+  case mxs of
+    Nothing ->
+      pure ()
+    Just xs0 ->
+      let
+        xs1 =
+          filter (/= region) xs0
+      in
+        TMVar.putTMVar Console.regionList (region : xs1)
+
+finishRegion :: LiftRegion m => Region -> m ()
+finishRegion (Region var) =
+  liftRegion $ do
+    mregion <- TVar.readTVar var
+    case mregion of
+      Nothing ->
+        pure ()
+
+      Just region -> do
+        content <- Console.getConsoleRegion region
+        Console.finishConsoleRegion region content

--- a/hedgehog/src/Hedgehog/Internal/Runner.hs
+++ b/hedgehog/src/Hedgehog/Internal/Runner.hs
@@ -17,30 +17,26 @@ module Hedgehog.Internal.Runner (
 
   -- * Internal
   , checkReport
-  , checkConsoleRegion
+  , checkRegion
   , checkNamed
   ) where
 
-import           Control.Concurrent.Async (forConcurrently)
-import           Control.Concurrent.MVar (MVar)
-import qualified Control.Concurrent.MVar as MVar
-import           Control.Concurrent.STM (STM, atomically)
-import qualified Control.Concurrent.STM.TMVar as TMVar
-import           Control.Monad (when)
-import           Control.Monad.Catch (MonadMask(..), MonadCatch(..), catchAll, bracket)
+import           Control.Concurrent.STM (TVar, atomically)
+import qualified Control.Concurrent.STM.TVar as TVar
+import           Control.Monad.Catch (MonadCatch(..), catchAll)
 import           Control.Monad.IO.Class (MonadIO(..))
 
-import           Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
-
-import qualified GHC.Conc as Conc
+import           Data.Semigroup ((<>))
 
 import           Hedgehog.Gen (runGen)
 import qualified Hedgehog.Gen as Gen
+import           Hedgehog.Internal.Config
 import           Hedgehog.Internal.Property (Group(..), GroupName(..))
 import           Hedgehog.Internal.Property (Property(..), PropertyConfig(..), PropertyName(..))
 import           Hedgehog.Internal.Property (ShrinkLimit, withTests)
 import           Hedgehog.Internal.Property (Test, Log(..), Failure(..), runTest)
+import           Hedgehog.Internal.Queue
+import           Hedgehog.Internal.Region
 import           Hedgehog.Internal.Report
 import           Hedgehog.Internal.Seed (Seed)
 import qualified Hedgehog.Internal.Seed as Seed
@@ -49,11 +45,8 @@ import           Hedgehog.Range (Size)
 
 import           Language.Haskell.TH.Lift (deriveLift)
 
-import           System.Console.Regions (ConsoleRegion, RegionLayout(..), LiftRegion)
+import           System.Console.Regions (ConsoleRegion, RegionLayout(..))
 import qualified System.Console.Regions as Console
-import           System.Environment (lookupEnv)
-
-import           Text.Read (readMaybe)
 
 
 -- | Configuration for a property test run.
@@ -62,7 +55,15 @@ data RunnerConfig =
   RunnerConfig {
       -- | The number of property tests to run concurrently. 'Nothing' means
       --   use one worker per processor.
-      runnerWorkers :: !(Maybe Int)
+      runnerWorkers :: !(Maybe WorkerCount)
+
+      -- | Whether to use colored output or not. 'Nothing' means detect from
+      --   the environment.
+    , runnerColor :: !(Maybe UseColor)
+
+      -- | How verbose to be in the runner output. 'Nothing' means detect from
+      --   the environment.
+    , runnerVerbosity :: !(Maybe Verbosity)
     } deriving (Eq, Ord, Show)
 
 findM :: Monad m => [a] -> b -> (a -> m (Maybe b)) -> m b
@@ -180,39 +181,54 @@ checkReport cfg size0 seed0 test0 updateUI =
   in
     loop 0 0 size0 seed0
 
-checkConsoleRegion ::
+checkRegion ::
      MonadIO m
-  => ConsoleRegion
+  => Region
+  -> Maybe UseColor
   -> Maybe PropertyName
   -> Size
   -> Seed
   -> Property
   -> m (Report Result)
-checkConsoleRegion region name size seed prop =
+checkRegion region mcolor name size seed prop =
   liftIO $ do
     result <-
-      checkReport (propertyConfig prop) size seed (propertyTest prop) $ \status ->
-        Console.setConsoleRegion region =<<
-          renderProgress name status
+      checkReport (propertyConfig prop) size seed (propertyTest prop) $ \progress -> do
+        ppprogress <- renderProgress mcolor name progress
+        case reportStatus progress of
+          Running ->
+            setRegion region ppprogress
+          Shrinking _ ->
+            forceRegion region ppprogress
 
-    Console.setConsoleRegion region =<<
-      renderResult name result
+    ppresult <- renderResult mcolor name result
+    case reportStatus result of
+      Failed _ ->
+        forceRegion region ppresult
+      GaveUp ->
+        forceRegion region ppresult
+      OK ->
+        setRegion region ppresult
 
     pure result
 
-checkNamed :: MonadIO m => ConsoleRegion -> Maybe PropertyName -> Property -> m Bool
-checkNamed region name prop = do
+checkNamed ::
+     MonadIO m
+  => Region
+  -> Maybe UseColor
+  -> Maybe PropertyName
+  -> Property
+  -> m (Report Result)
+checkNamed region mcolor name prop = do
   seed <- liftIO Seed.random
-  result <- checkConsoleRegion region name 0 seed prop
-  pure $
-    reportStatus result == OK
+  checkRegion region mcolor name 0 seed prop
 
 -- | Check a property.
 --
 check :: MonadIO m => Property -> m Bool
 check prop =
   liftIO . displayRegion $ \region ->
-    checkNamed region Nothing prop
+    (== OK) . reportStatus <$> checkNamed region Nothing Nothing prop
 
 -- | Check a property using a specific size and seed.
 --
@@ -220,7 +236,7 @@ recheck :: MonadIO m => Size -> Seed -> Property -> m ()
 recheck size seed prop0 = do
   let prop = withTests 1 prop0
   _ <- liftIO . displayRegion $ \region ->
-    checkConsoleRegion region Nothing size seed prop
+    checkRegion region Nothing Nothing size seed prop
   pure ()
 
 -- | Check a group of properties using the specified runner config.
@@ -228,37 +244,80 @@ recheck size seed prop0 = do
 checkGroup :: MonadIO m => RunnerConfig -> Group -> m Bool
 checkGroup config (Group group props) =
   liftIO $ do
-    n <- maybe getNumWorkers pure (runnerWorkers config)
+    n <- resolveWorkers (runnerWorkers config)
 
     -- ensure few spare capabilities for concurrent-output, it's likely that
     -- our tests will saturate all the capabilities they're given.
     updateNumCapabilities (n + 2)
 
     putStrLn $ "━━━ " ++ unGroupName group ++ " ━━━"
-    Console.displayConsoleRegions $ do
-      remaining <- Console.openConsoleRegion Linear
 
-      let
-        start (TasksRemaining tasks) _ix (name, prop) =
-          liftIO $ do
-            ppremaining <- renderRemaining $ PropertyCount tasks
+    verbosity <- resolveVerbosity (runnerVerbosity config)
+    summary <- checkGroupWith n verbosity (runnerColor config) props
 
-            atomically $ do
-              region <- Console.openConsoleRegion Linear
-              moveToBottom remaining
+    pure $
+      summaryFailed summary == 0 &&
+      summaryGaveUp summary == 0
 
-              if tasks == 0 then
-                Console.closeConsoleRegion remaining
-              else
-                Console.setConsoleRegion remaining ppremaining
+updateSummary :: ConsoleRegion -> TVar Summary -> Maybe UseColor -> (Summary -> Summary) -> IO ()
+updateSummary sregion svar mcolor f = do
+  summary <- atomically (TVar.modifyTVar' svar f >> TVar.readTVar svar)
+  Console.setConsoleRegion sregion =<< renderSummary mcolor summary
 
-              pure (name, prop, region)
+checkGroupWith ::
+     WorkerCount
+  -> Verbosity
+  -> Maybe UseColor
+  -> [(PropertyName, Property)]
+  -> IO Summary
+checkGroupWith n verbosity mcolor props =
+  displayRegions $ do
+    sregion <- Console.openConsoleRegion Linear
+    svar <- atomically . TVar.newTVar $ mempty { summaryWaiting = PropertyCount (length props) }
 
-        finalize (_name, _prop, region) =
-          finishRegion region
+    let
+      start (TasksRemaining tasks) _ix (name, prop) =
+        liftIO $ do
+          updateSummary sregion svar mcolor $ \x -> x {
+              summaryWaiting =
+                PropertyCount tasks
+            , summaryRunning =
+                summaryRunning x + 1
+            }
 
-      runTasks n props start finalize $ \(name, prop, region) ->
-        checkNamed region (Just name) prop
+          atomically $ do
+            region <-
+              case verbosity of
+                Quiet ->
+                  newEmptyRegion
+                Normal ->
+                  newRegion
+
+            moveToBottom sregion
+
+            pure (name, prop, region)
+
+      finish (_name, _prop, _region) =
+        updateSummary sregion svar mcolor $ \x -> x {
+            summaryRunning =
+              summaryRunning x - 1
+          }
+
+      finalize (_name, _prop, region) =
+        finishRegion region
+
+    summary <-
+      fmap (mconcat . fmap (fromResult . reportStatus)) $
+        runTasks n props start finish finalize $ \(name, prop, region) -> do
+          result <- checkNamed region mcolor (Just name) prop
+          updateSummary sregion svar mcolor
+            (<> fromResult (reportStatus result))
+          pure result
+
+    updateSummary sregion svar mcolor (const summary)
+    Console.finishConsoleRegion sregion =<< Console.getConsoleRegion sregion
+
+    pure summary
 
 -- | Check a group of properties sequentially.
 --
@@ -283,9 +342,13 @@ checkSequential =
     RunnerConfig {
         runnerWorkers =
           Just 1
+      , runnerColor =
+          Nothing
+      , runnerVerbosity =
+          Nothing
       }
 
--- | Check a group of properties concurrently.
+-- | Check a group of properties in parallel.
 --
 --   Using Template Haskell for property discovery:
 --
@@ -307,137 +370,11 @@ checkConcurrent =
     RunnerConfig {
         runnerWorkers =
           Nothing
+      , runnerColor =
+          Nothing
+      , runnerVerbosity =
+          Nothing
       }
-
-------------------------------------------------------------------------
--- quick and dirty task queue
-
-newtype TaskIndex =
-  TaskIndex Int
-  deriving (Eq, Ord, Enum, Num)
-
-newtype TasksRemaining =
-  TasksRemaining Int
-
-dequeueMVar ::
-     MVar [(TaskIndex, a)]
-  -> (TasksRemaining -> TaskIndex -> a -> IO b)
-  -> IO (Maybe (TaskIndex, b))
-dequeueMVar mvar start =
-  MVar.modifyMVar mvar $ \case
-    [] ->
-      pure ([], Nothing)
-    (ix, x) : xs -> do
-      y <- start (TasksRemaining $ length xs) ix x
-      pure (xs, Just (ix, y))
-
-runTasks ::
-     Int
-  -> [a]
-  -> (TasksRemaining -> TaskIndex -> a -> IO b)
-  -> (b -> IO ())
-  -> (b -> IO Bool)
-  -> IO Bool
-runTasks n tasks start finalize runTask = do
-  qvar <- MVar.newMVar (zip [0..] tasks)
-  fvar <- MVar.newMVar (-1, Map.empty)
-
-  let
-    worker r0 = do
-      mx <- dequeueMVar qvar start
-      case mx of
-        Nothing ->
-          pure r0
-        Just (ix, x) -> do
-          r <- runTask x
-          finalizeTask fvar ix (finalize x)
-          worker (r0 && r)
-
-  -- FIXME ensure all workers have finished running
-  fmap and . forConcurrently [1..max 1 n] $ \_ix ->
-    worker True
-
-runActiveFinalizers ::
-     MonadIO m
-  => MVar (TaskIndex, Map TaskIndex (IO ()))
-  -> m ()
-runActiveFinalizers mvar =
-  liftIO $ do
-    again <-
-      MVar.modifyMVar mvar $ \original@(minIx, finalizers0) ->
-        case Map.minViewWithKey finalizers0 of
-          Nothing ->
-            pure (original, False)
-
-          Just ((ix, finalize), finalizers) ->
-            if ix == minIx + 1 then do
-              finalize
-              pure ((ix, finalizers), True)
-            else
-              pure (original, False)
-
-    when again $
-      runActiveFinalizers mvar
-
-finalizeTask ::
-     MonadIO m
-  => MVar (TaskIndex, Map TaskIndex (IO ()))
-  -> TaskIndex
-  -> IO ()
-  -> m ()
-finalizeTask mvar ix finalize = do
-  liftIO . MVar.modifyMVar_ mvar $ \(minIx, finalizers) ->
-    pure (minIx, Map.insert ix finalize finalizers)
-  runActiveFinalizers mvar
-
-------------------------------------------------------------------------
--- concurrent-output utils
-
-displayRegion ::
-     MonadIO m
-  => MonadMask m
-  => LiftRegion m
-  => (ConsoleRegion -> m a)
-  -> m a
-displayRegion =
-  Console.displayConsoleRegions .
-  bracket (Console.openConsoleRegion Linear) finishRegion
-
-moveToBottom :: ConsoleRegion -> STM ()
-moveToBottom region = do
-  mxs <- TMVar.tryTakeTMVar Console.regionList
-  case mxs of
-    Nothing ->
-      pure ()
-    Just xs0 ->
-      let
-        xs1 =
-          filter (/= region) xs0
-      in
-        TMVar.putTMVar Console.regionList (region : xs1)
-
-finishRegion :: MonadIO m => ConsoleRegion -> m ()
-finishRegion region =
-  liftIO . atomically $ do
-    content <- Console.getConsoleRegion region
-    Console.finishConsoleRegion region content
-
--- | Update the number of capabilities but never set it lower than it already
---   is.
---
-updateNumCapabilities :: Int -> IO ()
-updateNumCapabilities n = do
-  ncaps <- Conc.getNumCapabilities
-  Conc.setNumCapabilities (max n ncaps)
-
-getNumWorkers :: IO Int
-getNumWorkers = do
-  menv <- (readMaybe =<<) <$> lookupEnv "HEDGEHOG_WORKERS"
-  case menv of
-    Nothing ->
-      Conc.getNumProcessors
-    Just env ->
-      pure env
 
 ------------------------------------------------------------------------
 -- FIXME Replace with DeriveLift when we drop 7.10 support.


### PR DESCRIPTION
This resolves https://github.com/hedgehogqa/haskell-hedgehog/issues/51 by adding an optional quieter test runner.

It can be activated in code using `checkGroup` or by setting the environment variable `HEDGEHOG_VERBOSITY=0`.

Ideally the ANSI color configuration and test runner verbosity could also be set using a user config file, but that's for another PR.

Some screenshots:
<img width="185" alt="screen shot 2017-04-21 at 12 15 30 pm" src="https://cloud.githubusercontent.com/assets/134805/25262857/d35540d6-268d-11e7-850f-ed1a7b253b73.png">
<img width="187" alt="screen shot 2017-04-21 at 12 15 35 pm" src="https://cloud.githubusercontent.com/assets/134805/25262864/db3ce894-268d-11e7-886c-57a256978655.png">
<img width="425" alt="screen shot 2017-04-21 at 12 27 55 pm" src="https://cloud.githubusercontent.com/assets/134805/25262888/fbb59a6c-268d-11e7-8483-c0338369510e.png">

/cc @chris-martin 