### PR TITLE
Add helper for observing pure values

### DIFF
--- a/hedgehog/src/Hedgehog.hs
+++ b/hedgehog/src/Hedgehog.hs
@@ -72,6 +72,7 @@ module Hedgehog (
   -- * Test
   , forAll
   , info
+  , input
   , success
   , discard
   , failure
@@ -89,7 +90,7 @@ import           Hedgehog.Gen (Gen)
 import           Hedgehog.Internal.Property (assert, (===))
 import           Hedgehog.Internal.Property (discard, failure, success)
 import           Hedgehog.Internal.Property (DiscardLimit, withDiscards)
-import           Hedgehog.Internal.Property (forAll, info)
+import           Hedgehog.Internal.Property (forAll, info, input)
 import           Hedgehog.Internal.Property (liftEither, liftExceptT, withResourceT)
 import           Hedgehog.Internal.Property (Property, PropertyName, Group(..), GroupName)
 import           Hedgehog.Internal.Property (ShrinkLimit, withShrinks)

--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -36,6 +36,7 @@ module Hedgehog.Internal.Property (
   , Diff(..)
   , forAll
   , info
+  , input
   , discard
   , failure
   , success
@@ -334,14 +335,21 @@ writeLog =
 forAll :: (Monad m, Show a, Typeable a, HasCallStack) => Gen m a -> Test m a
 forAll gen = do
   x <- Test . lift $ lift gen
-  writeLog $ Input (getCaller callStack) (typeOf x) (showPretty x)
-  return x
+  input x
 
 -- | Logs an information message to be displayed if the test fails.
 --
 info :: Monad m => String -> Test m ()
 info =
   writeLog . Info
+
+-- | Adds a value to the log, such that it appears in counterexample reports.
+--
+-- Equivalent to @forAll . pure@
+--
+input :: (Monad m, Show a, Typeable a, HasCallStack) => a -> Test m a
+input x =
+  (writeLog $ Input (getCaller callStack) (typeOf x) (showPretty x)) *> pure x
 
 -- | Discards a test entirely.
 --


### PR DESCRIPTION
We already have `info` as something corresponding to QuickCheck's `counterexample`, but generated values get a really nice presentation out of the box. I'd like to be able to render pure values this way too, since subexpressions can be just as important as the generated value when trying to understand a counterexample.

In Jack and Hedgehog thus far I've used `forAll (pure x)` to achieve this. It's been really useful, so I'd like to recommend it as part of the API.

Not sure about the name. I was thinking something like `observe` would be nice?

@jystic @charleso 