### PR TITLE
Rename checkConcurrent -> checkParallel

### DIFF
--- a/hedgehog-example/test/Test/Example/STLC.hs
+++ b/hedgehog-example/test/Test/Example/STLC.hs
@@ -331,4 +331,4 @@ prop_idempotent6 =
 
 tests :: IO Bool
 tests =
-  checkConcurrent $$(discover)
+  checkParallel $$(discover)

--- a/hedgehog/src/Hedgehog.hs
+++ b/hedgehog/src/Hedgehog.hs
@@ -24,14 +24,14 @@
 --
 -- > tests :: IO Bool
 -- > tests =
--- >   checkConcurrent $$(discover)
+-- >   checkParallel $$(discover)
 --
 -- If you prefer to avoid macros, you can specify the group of properties to
 -- run manually instead:
 --
 -- > tests :: IO Bool
 -- > tests =
--- >   checkConcurrent $ Group "Test.Example" [
+-- >   checkParallel $ Group "Test.Example" [
 -- >       ("prop_reverse", prop_reverse)
 -- >     ]
 --
@@ -66,7 +66,7 @@ module Hedgehog (
   , recheck
 
   , discover
-  , checkConcurrent
+  , checkParallel
   , checkSequential
 
   -- * Test
@@ -95,7 +95,7 @@ import           Hedgehog.Internal.Property (Property, PropertyName, Group(..), 
 import           Hedgehog.Internal.Property (ShrinkLimit, withShrinks)
 import           Hedgehog.Internal.Property (Test, property)
 import           Hedgehog.Internal.Property (TestLimit, withTests)
-import           Hedgehog.Internal.Runner (check, recheck, checkSequential, checkConcurrent)
+import           Hedgehog.Internal.Runner (check, recheck, checkSequential, checkParallel)
 import           Hedgehog.Internal.Seed (Seed(..))
 import           Hedgehog.Internal.TH (discover)
 import           Hedgehog.Internal.Tripping (tripping)

--- a/hedgehog/src/Hedgehog/Internal/Runner.hs
+++ b/hedgehog/src/Hedgehog/Internal/Runner.hs
@@ -350,6 +350,12 @@ checkSequential =
 
 -- | Check a group of properties in parallel.
 --
+--   /Warning: although this check function runs tests faster than/
+--   /'checkSequential', it should be noted that it may cause problems with/
+--   /properties that are not self-contained. For example, if you have a group/
+--   /of tests which all use the same database table, you may find that they/
+--   /interfere with each other when being run in parallel./
+--
 --   Using Template Haskell for property discovery:
 --
 -- > tests :: IO Bool

--- a/hedgehog/src/Hedgehog/Internal/Runner.hs
+++ b/hedgehog/src/Hedgehog/Internal/Runner.hs
@@ -11,7 +11,7 @@ module Hedgehog.Internal.Runner (
 
   -- * Running Groups of Properties
   , RunnerConfig(..)
-  , checkConcurrent
+  , checkParallel
   , checkSequential
   , checkGroup
 
@@ -354,18 +354,18 @@ checkSequential =
 --
 -- > tests :: IO Bool
 -- > tests =
--- >   checkConcurrent $$(discover)
+-- >   checkParallel $$(discover)
 --
 --   With manually specified properties:
 --
 -- > tests :: IO Bool
 -- > tests =
--- >   checkConcurrent $ Group "Test.Example" [
+-- >   checkParallel $ Group "Test.Example" [
 -- >       ("prop_reverse", prop_reverse)
 -- >     ]
 --
-checkConcurrent :: MonadIO m => Group -> m Bool
-checkConcurrent =
+checkParallel :: MonadIO m => Group -> m Bool
+checkParallel =
   checkGroup
     RunnerConfig {
         runnerWorkers =

--- a/hedgehog/test/Test/Hedgehog/Text.hs
+++ b/hedgehog/test/Test/Hedgehog/Text.hs
@@ -73,4 +73,4 @@ prop_tripping_append_seed =
 
 tests :: IO Bool
 tests =
-  checkConcurrent $$(discover)
+  checkParallel $$(discover)


### PR DESCRIPTION
I think it's technically more correct to say that we're running the tests in parallel, as the goal is improved throughput, and there is no non-deterministic control flow.

I thought I would rename this before release as there is already a breaking change in this area due to the introduction of `$$(discover)`