### PR TITLE
Use const, in order to be consistent with the other places where it's used

### DIFF
--- a/hedgehog/src/Hedgehog/Gen.hs
+++ b/hedgehog/src/Hedgehog/Gen.hs
@@ -1019,7 +1019,7 @@ uniqueInsert n xs kvs0 =
       [] ->
         Right xs
       (k, v) : kvs ->
-        uniqueInsert n (Map.insertWith (\x _ -> x) k v xs) kvs
+        uniqueInsert n (Map.insertWith const k v xs) kvs
 
 -- | Check that list contains at least a certain number of elements.
 --

--- a/hedgehog/src/Hedgehog/Range.hs
+++ b/hedgehog/src/Hedgehog/Range.hs
@@ -119,7 +119,7 @@ upperBound sz range =
 --
 singleton :: a -> Range a
 singleton x =
-  Range x $ \_ -> (x, x)
+  Range x $ const (x, x)
 
 -- | Construct a range which is unaffected by the size parameter.
 --
@@ -156,7 +156,7 @@ constant x y =
 --
 constantFrom :: a -> a -> a -> Range a
 constantFrom z x y =
-  Range z $ \_ -> (x, y)
+  Range z $ const (x, y)
 
 -- | Construct a range which is unaffected by the size parameter using the full
 --   range of a data type.


### PR DESCRIPTION
Looks like there's `\x _ -> x` in some places and `const` in some others, so I thought we could just use `const` there as well (?)

```
Searching 17 files for "const "

..\haskell-hedgehog\hedgehog\src\Hedgehog\Gen.hs:
 1027  atLeast n =
 1028    if n == 0 then
 1029:     const True
 1030    else
 1031      not . null . drop (n - 1)
 ....
 1143  subsequence :: Monad m => [a] -> Gen m [a]
 1144  subsequence xs =
 1145:   shrink Shrink.list $ filterM (const bool_) xs
 1146  
 1147  -- | Generates a random permutation of a list.

..\haskell-hedgehog\hedgehog\src\Hedgehog\Internal\Report.hs:
  409  defaultStyle :: Declaration a -> Declaration (Style, [(Style, Doc Markup)])
  410  defaultStyle =
  411:   fmap $ const (StyleInfo, [])
  412  
  413  lastLineSpan :: Monad m => Span -> Declaration a -> MaybeT m (ColumnNo, ColumnNo)
  ...
  456  
  457        styleInput kvs =
  458:         foldr (Map.adjust . fmap . first $ const StyleInput) kvs [startLine..endLine]
  459  
  460        insertDoc =
  461:         Map.adjust (fmap . second $ const valDocs) endLine
  462  
  463      pure $
  ...
  540  
  541        styleFailure kvs =
  542:         foldr (Map.adjust . fmap . first $ const StyleFailure) kvs [startLine..endLine]
  543  
  544        insertDoc =
  545:         Map.adjust (fmap . second $ const docs) endLine
  546  
  547      pure $

..\haskell-hedgehog\hedgehog\src\Hedgehog\Internal\Runner.hs:
  315            pure result
  316  
  317:     updateSummary sregion svar mcolor (const summary)
  318      Console.finishConsoleRegion sregion =<< Console.getConsoleRegion sregion
  319  

8 matches across 3 files
```