### PR TITLE
Remove use of Typeable / allow custom render function

### DIFF
--- a/hedgehog/src/Hedgehog.hs
+++ b/hedgehog/src/Hedgehog.hs
@@ -71,6 +71,7 @@ module Hedgehog (
 
   -- * Test
   , forAll
+  , forAllWith
   , info
   , success
   , discard
@@ -89,7 +90,7 @@ import           Hedgehog.Gen (Gen)
 import           Hedgehog.Internal.Property (assert, (===))
 import           Hedgehog.Internal.Property (discard, failure, success)
 import           Hedgehog.Internal.Property (DiscardLimit, withDiscards)
-import           Hedgehog.Internal.Property (forAll, info)
+import           Hedgehog.Internal.Property (forAll, forAllWith, info)
 import           Hedgehog.Internal.Property (liftEither, liftExceptT, withResourceT)
 import           Hedgehog.Internal.Property (Property, PropertyName, Group(..), GroupName)
 import           Hedgehog.Internal.Property (ShrinkLimit, withShrinks)


### PR DESCRIPTION
It was only for 7.10 anyway, and it turns out that some type level hackery can't be used with a `Typeable` constraint. This, in conjunction with a custom render function, will allow those situations to work properly.