### PR TITLE
Add 'annotate' function for annotating source code with additional info

### DIFF
--- a/hedgehog/src/Hedgehog.hs
+++ b/hedgehog/src/Hedgehog.hs
@@ -72,7 +72,10 @@ module Hedgehog (
   -- * Test
   , forAll
   , forAllWith
+  , annotate
+  , annotateShow
   , footnote
+  , footnoteShow
   , success
   , discard
   , failure
@@ -90,7 +93,9 @@ import           Hedgehog.Gen (Gen)
 import           Hedgehog.Internal.Property (assert, (===))
 import           Hedgehog.Internal.Property (discard, failure, success)
 import           Hedgehog.Internal.Property (DiscardLimit, withDiscards)
-import           Hedgehog.Internal.Property (forAll, forAllWith, footnote)
+import           Hedgehog.Internal.Property (forAll, forAllWith)
+import           Hedgehog.Internal.Property (annotate, annotateShow)
+import           Hedgehog.Internal.Property (footnote, footnoteShow)
 import           Hedgehog.Internal.Property (liftEither, liftExceptT, withResourceT)
 import           Hedgehog.Internal.Property (Property, PropertyName, Group(..), GroupName)
 import           Hedgehog.Internal.Property (ShrinkLimit, withShrinks)


### PR DESCRIPTION
This implements the `annotate` feature as discussed in https://github.com/hedgehogqa/haskell-hedgehog/pull/60 (so I will close that one)

<img width="528" alt="screen shot 2017-05-06 at 12 02 49 pm" src="https://cloud.githubusercontent.com/assets/134805/25769080/7828712e-3254-11e7-8f60-ecb24bdc0544.png">
