### PR TITLE
Add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+## Version 0.2 (2017-05-06)
+
+- Added a quiet test runner which can be activated by setting `HEDGEHOG_VERBOSITY=0`
+- Concurrent test runner does not display tests until they are executing.
+- Test runner now outputs a summary of how many successful / failed tests were run.
+- `checkSequential` and `checkParallel` now allow for tests to be run without Template Haskell.
+- Auto-discovery of properties is now available via `discover` instead of being baked in.
+- `annotate` allows source code to be annotated inline with extra information.
+- `forAllWith` can be used to generate values without a `Show` instance.
+- Removed uses of `Typeable` to allow for generating types which cannot implement it.

--- a/hedgehog/CHANGELOG.md
+++ b/hedgehog/CHANGELOG.md
@@ -1,0 +1,1 @@
+../CHANGELOG.md

--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -38,6 +38,7 @@ tested-with:
   , GHC == 8.0.2
 extra-source-files:
   README.md
+  CHANGELOG.md
 
 source-repository head
   type: git


### PR DESCRIPTION
Hackage complained when I uploaded a package candidate without a changelog, I though this was a good idea in any case.