### PR TITLE
Add ascii/latin1/unicode character generators

### DIFF
--- a/hedgehog-example/test/Test/Example/Basic.hs
+++ b/hedgehog-example/test/Test/Example/Basic.hs
@@ -6,6 +6,9 @@ module Test.Example.Basic where
 
 import           Control.Monad (guard)
 
+import qualified Data.List as List
+import qualified Data.Text as Text
+
 import           Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
@@ -249,6 +252,24 @@ prop_record =
     x <- forAll genRecord
     y <- forAll genRecord
     x === y
+
+------------------------------------------------------------------------
+-- Example 6 - Text.takeEnd
+
+prop_takeEnd :: Property
+prop_takeEnd =
+  property $ do
+    xs <- forAll $ Gen.string (Range.linear 0 100) Gen.unicode
+    n <- forAll $ Gen.int (Range.linear 0 100)
+
+    let
+      string =
+        List.reverse . List.take (fromIntegral n) $ List.reverse xs
+
+      text =
+        Text.unpack . Text.takeEnd n $ Text.pack xs
+
+    string === text
 
 ------------------------------------------------------------------------
 

--- a/hedgehog/src/Hedgehog/Gen.hs
+++ b/hedgehog/src/Hedgehog/Gen.hs
@@ -65,6 +65,10 @@ module Hedgehog.Gen (
   , upper
   , alpha
   , alphaNum
+  , ascii
+  , latin1
+  , unicode
+  , unicodeAll
 
   -- ** Strings
   , string
@@ -126,6 +130,9 @@ module Hedgehog.Gen (
 
   -- ** Shrinking
   , atLeast
+
+  -- ** Characters
+  , isSurrogate
 
   -- ** Subterms
   , Vec(..)
@@ -728,6 +735,38 @@ alphaNum :: Monad m => Gen m Char
 alphaNum =
   -- FIXME optimize lookup, use a SmallArray or something.
   element "abcdefghiklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+-- | Generates an ASCII character: @'\0'..'\127'@
+--
+ascii :: Monad m => Gen m Char
+ascii =
+  enum '\0' '\127'
+
+-- | Generates a Latin-1 character: @'\0'..'\255'@
+--
+latin1 :: Monad m => Gen m Char
+latin1 =
+  enum '\0' '\255'
+
+-- | Generates a Unicode character, excluding invalid standalone surrogates:
+--   @'\0'..'\1114111' (excluding '\55296'..'\57344')@
+--
+unicode :: Monad m => Gen m Char
+unicode =
+  filter (not . isSurrogate) unicodeAll
+
+-- | Generates a Unicode character, including invalid standalone surrogates:
+--   @'\0'..'\1114111'@
+--
+unicodeAll :: Monad m => Gen m Char
+unicodeAll =
+  enumBounded
+
+-- | Check if a character is in the surrogate category.
+--
+isSurrogate :: Char -> Bool
+isSurrogate x =
+  x >= '\55296' && x <= '\57344'
 
 ------------------------------------------------------------------------
 -- Combinators - Strings


### PR DESCRIPTION
This adds some generators for various character sets, and a property test which fails with the current version of `text` on Hackage as an example usage.

The test was inspired by https://github.com/bos/text/issues/176 and the generator choices are similar to the ones which have recently been added to QuickCheck using `Arbitrary` instances for `Char` newtypes.

<img width="537" alt="screen shot 2017-05-06 at 5 42 32 pm" src="https://cloud.githubusercontent.com/assets/134805/25770833/7511b6d8-3283-11e7-930f-4573b7d09453.png">



