### PR TITLE
Use (DFFF)16/(57343)10 as the low surrogate

### DIFF
--- a/hedgehog/src/Hedgehog/Gen.hs
+++ b/hedgehog/src/Hedgehog/Gen.hs
@@ -749,7 +749,7 @@ latin1 =
   enum '\0' '\255'
 
 -- | Generates a Unicode character, excluding invalid standalone surrogates:
---   @'\0'..'\1114111' (excluding '\55296'..'\57344')@
+--   @'\0'..'\1114111' (excluding '\55296'..'\57343')@
 --
 unicode :: Monad m => Gen m Char
 unicode =
@@ -766,7 +766,7 @@ unicodeAll =
 --
 isSurrogate :: Char -> Bool
 isSurrogate x =
-  x >= '\55296' && x <= '\57344'
+  x >= '\55296' && x <= '\57343'
 
 ------------------------------------------------------------------------
 -- Combinators - Strings


### PR DESCRIPTION
I came across this while porting https://github.com/hedgehogqa/haskell-hedgehog/pull/73/ to the F# version: https://github.com/hedgehogqa/fsharp-hedgehog/pull/96/.

See also:
- https://en.wikipedia.org/wiki/Universal_Character_Set_characters#Surrogates
- https://referencesource.microsoft.com/#mscorlib/system/char.cs,913
