### PR TITLE
Add Test.Hedgehog.Text to other modules

### DIFF
--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -117,7 +117,7 @@ test-suite test
     test
 
   other-modules:
-      Test.Hedgehog.Text
+    Test.Hedgehog.Text
 
   build-depends:
       hedgehog

--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -116,6 +116,9 @@ test-suite test
   hs-source-dirs:
     test
 
+  other-modules:
+      Test.Hedgehog.Text
+
   build-depends:
       hedgehog
     , base                            >= 3          && < 5


### PR DESCRIPTION
So that it's included in distribution. Currently build is failing on hydra: http://hydra.nixos.org/build/51844414/nixlog/1