### PR TITLE
Add roundtrip test from Tim's blog post

### DIFF
--- a/hedgehog-example/hedgehog-example.cabal
+++ b/hedgehog-example/hedgehog-example.cabal
@@ -47,6 +47,7 @@ test-suite test
     , filepath                        >= 1.3        && < 1.4
     , mmorph                          >= 1.0        && < 1.1
     , mtl                             >= 2.1        && < 2.3
+    , parsec                          >= 3.1        && < 3.2
     , pretty-show                     >= 1.6        && < 1.7
     , process                         >= 1.2        && < 1.7
     , resourcet                       >= 1.1        && < 1.2

--- a/hedgehog-example/test/Test/Example/Roundtrip.hs
+++ b/hedgehog-example/test/Test/Example/Roundtrip.hs
@@ -1,0 +1,155 @@
+--
+-- See the original post for a description of this example:
+--
+--   http://teh.id.au/posts/2017/06/07/round-trip-property
+--
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Test.Example.Roundtrip where
+
+import           Control.Monad (void, guard)
+import           Control.Applicative (Alternative(..))
+
+import           Data.Text (Text)
+import qualified Data.Text as Text
+
+import           Hedgehog
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+import           Text.Parsec (ParseError)
+import qualified Text.Parsec as Parsec
+import           Text.Parsec.Text (Parser)
+import           Text.Printf (printf)
+import           Text.Read (readMaybe)
+
+
+data Token =
+    TInt Int
+  | TFloat Double
+  | TAssign
+  | TPlus
+  | TPlusEq
+  | TVar Text
+  | TLParen
+  | TRParen
+  | TIncrement
+  | TSeparator
+    deriving (Eq, Ord, Show)
+
+renderToken :: Token -> Text
+renderToken t =
+  case t of
+    TInt x ->
+      Text.pack (show x)
+    TFloat d ->
+      Text.pack (printf "%6f" d)
+    TAssign ->
+      ":="
+    TPlus ->
+      "+"
+    TPlusEq ->
+      "+="
+    TVar x ->
+      x
+    TLParen ->
+      "("
+    TRParen ->
+      ")"
+    TIncrement ->
+      "++"
+    TSeparator ->
+      ";"
+
+pretty :: [Token] -> Text
+pretty =
+  Text.intercalate " " . fmap renderToken
+
+whitespace :: Parser ()
+whitespace =
+  void (many Parsec.space)
+
+parseInt :: Parser Int
+parseInt = do
+  xyz <- Parsec.many1 Parsec.digit
+  case readMaybe xyz of
+    Just x ->
+      pure x
+    Nothing ->
+      empty
+
+parseDouble :: Parser Double
+parseDouble = do
+  a <- Parsec.many1 Parsec.digit
+  _ <- Parsec.char '.'
+  b <- Parsec.many1 Parsec.digit
+  guard (length b <= 6)
+  case readMaybe (a ++ "." ++ b) of
+    Just x ->
+      pure x
+    Nothing ->
+      empty
+
+parseVar :: Parser Text
+parseVar =
+  fmap Text.pack (Parsec.many1 Parsec.letter)
+
+parseToken :: Parser Token
+parseToken =
+  Parsec.choice [
+      TFloat <$> Parsec.try parseDouble
+    , TInt <$> parseInt
+    , TVar <$> parseVar
+    , Parsec.try (Parsec.string "++") *> pure TIncrement
+    , Parsec.try (Parsec.string "+=") *> pure TPlusEq
+    , Parsec.string ":=" *> pure TAssign
+    , Parsec.string "+" *> pure TPlus
+    , Parsec.string "(" *> pure TLParen
+    , Parsec.string ")" *> pure TRParen
+    , Parsec.string ";" *> pure TSeparator
+    ]
+
+parseTokens :: Parser [Token]
+parseTokens = do
+  whitespace
+  Parsec.many (parseToken <* whitespace)
+
+parse :: Text -> Either ParseError [Token]
+parse =
+  -- You almost always want to parse until EOF when using Parsec!
+  Parsec.parse (parseTokens <* Parsec.eof) ""
+
+------------------------------------------------------------------------
+
+genTokens :: Monad m => Gen m [Token]
+genTokens =
+  Gen.list (Range.linear 0 100) genToken
+
+round6 :: Double -> Double
+round6 x =
+  fromInteger (round (x * (10 ^ (6 :: Int)))) / 10.0 ^^ (6 :: Int)
+
+genToken :: Monad m => Gen m Token
+genToken =
+  Gen.choice [
+      TInt <$> Gen.int (Range.linear 0 maxBound)
+    , TFloat . round6 <$> Gen.double (Range.exponentialFloat 0.0 9223372036854775807.9)
+    , pure TAssign
+    , pure TPlus
+    , pure TPlusEq
+    , TVar <$> Gen.text (Range.linear 1 20) Gen.alpha
+    , pure TLParen
+    , pure TRParen
+    , pure TIncrement
+    , pure TSeparator
+    ]
+
+prop_trip :: Property
+prop_trip =
+  withTests 1000 . property $ do
+    toks <- forAll genTokens
+    tripping toks pretty parse
+
+tests :: IO Bool
+tests =
+  checkParallel $$(discover)


### PR DESCRIPTION
I hope @thumphries doesn't mind, I turned his [blog post](http://teh.id.au/posts/2017/06/07/round-trip-property/) in to an example.

While I was doing so I noticed that the `tripping` function could be improved a bit, I added an output with the intermediate value:
<img width="452" alt="screen shot 2017-06-11 at 11 37 54 am" src="https://user-images.githubusercontent.com/134805/27007580-ee9be1d0-4e9a-11e7-8047-a44215b66284.png">

I understand that the intermediate value may not always be something supporting `Show` and could potentially be large, but I think this behaviour is a nice default. I think longer term we should have a `trippingWith` function which is a bit more configurable, but this is ok for now.
