### PR TITLE
Easier to use variables for state machine testing

### DIFF
--- a/hedgehog-example/test/test.hs
+++ b/hedgehog-example/test/test.hs
@@ -1,7 +1,10 @@
 import           System.IO (BufferMode(..), hSetBuffering, stdout, stderr)
 
 import qualified Test.Example.Basic as Test.Example.Basic
+import qualified Test.Example.References as Test.Example.References
+import qualified Test.Example.Registry as Test.Example.Registry
 import qualified Test.Example.Resource as Test.Example.Resource
+import qualified Test.Example.Roundtrip as Test.Example.Roundtrip
 import qualified Test.Example.STLC as Test.Example.STLC
 
 main :: IO ()
@@ -11,7 +14,10 @@ main = do
 
   _results <- sequence [
       Test.Example.Basic.tests
+    , Test.Example.References.tests
+    , Test.Example.Registry.tests
     , Test.Example.Resource.tests
+    , Test.Example.Roundtrip.tests
     , Test.Example.STLC.tests
     ]
 

--- a/hedgehog/src/Hedgehog.hs
+++ b/hedgehog/src/Hedgehog.hs
@@ -101,9 +101,12 @@ module Hedgehog (
   , Action
   , executeSequential
 
+  , Var(..)
+  , concrete
+  , opaque
+
+  , Symbolic
   , Concrete(..)
-  , Symbolic(..)
-  , Var
   , Opaque(..)
 
   -- * Transformers
@@ -145,6 +148,6 @@ import           Hedgehog.Internal.Runner (check, recheck, checkSequential, chec
 import           Hedgehog.Internal.Seed (Seed(..))
 import           Hedgehog.Internal.State (Command(..), Callback(..), Action)
 import           Hedgehog.Internal.State (executeSequential)
-import           Hedgehog.Internal.State (Var(..), Symbolic(..), Concrete(..))
+import           Hedgehog.Internal.State (Var(..), Symbolic, Concrete(..), concrete, opaque)
 import           Hedgehog.Internal.TH (discover)
 import           Hedgehog.Internal.Tripping (tripping)

--- a/hedgehog/src/Hedgehog/Internal/Opaque.hs
+++ b/hedgehog/src/Hedgehog/Internal/Opaque.hs
@@ -11,8 +11,10 @@ module Hedgehog.Internal.Opaque (
 --   For example:
 --
 -- @
---   data Ref v =
---     Ref (v (Opaque (IORef Int)))
+--   data State v =
+--     State {
+--         stateRefs :: [Var (Opaque (IORef Int)) v]
+--       } deriving (Eq, Show)
 -- @
 --
 newtype Opaque a =


### PR DESCRIPTION
This adds an extra data type for working with state machine variables. It frees the user from having to derive `Eq`, `Ord`, `Show` by hand for data structures which contain variables.

This PR also adds an extra argument to the `Ensure` callback which is the previous state. Having the previous and the current state can sometimes be useful when writing post-conditions.