### PR TITLE
Better support for tests which throw exceptions

### DIFF
--- a/hedgehog-example/test/Test/Example/Exception.hs
+++ b/hedgehog-example/test/Test/Example/Exception.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fno-warn-incomplete-patterns #-}
+module Test.Example.Exception where
+
+import qualified Data.List as List
+
+import           Hedgehog
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+import           Prelude hiding (maximum, filter)
+
+filter :: Ord a => (a -> Bool) -> [a] -> [a]
+filter _ (_ : _ : _ : _ : _) = error "too many!"
+filter _ [] = []
+filter p (x : xs) =
+  if p x then
+    x : filter p xs
+  else
+    filter p xs
+
+maximum :: Ord a => [a] -> a
+maximum (x : xs) = x `max` maximum xs
+
+prop_equals :: Property
+prop_equals =
+  property $ do
+    xs <- forAll $ Gen.list (Range.linear 1 100) (Gen.int Range.constantBounded)
+    maximum xs === List.maximum xs
+
+prop_assert :: Property
+prop_assert =
+  property $ do
+    xs <- forAll $ Gen.list (Range.linear 1 100) (Gen.int Range.constantBounded)
+    assert $
+      filter (== 0) xs == []
+
+prop_property_exception :: Property
+prop_property_exception =
+  property $ do
+    _xs <- forAll $ Gen.list (Range.linear 1 100) (Gen.int Range.constantBounded)
+    _x <- error "got an error"
+    assert True
+
+return []
+tests :: IO Bool
+tests =
+  checkSequential $$(discover)

--- a/hedgehog-example/test/test.hs
+++ b/hedgehog-example/test/test.hs
@@ -1,6 +1,7 @@
 import           System.IO (BufferMode(..), hSetBuffering, stdout, stderr)
 
 import qualified Test.Example.Basic as Test.Example.Basic
+import qualified Test.Example.Exception as Test.Example.Exception
 import qualified Test.Example.References as Test.Example.References
 import qualified Test.Example.Registry as Test.Example.Registry
 import qualified Test.Example.Resource as Test.Example.Resource
@@ -14,6 +15,7 @@ main = do
 
   _results <- sequence [
       Test.Example.Basic.tests
+    , Test.Example.Exception.tests
     , Test.Example.References.tests
     , Test.Example.Registry.tests
     , Test.Example.Resource.tests

--- a/hedgehog/src/Hedgehog.hs
+++ b/hedgehog/src/Hedgehog.hs
@@ -84,6 +84,7 @@ module Hedgehog (
   , assert
   , (===)
 
+  , evaluate
   , liftCatch
   , liftCatchIO
   , liftEither
@@ -135,6 +136,7 @@ import           Hedgehog.Internal.Property (annotate, annotateShow)
 import           Hedgehog.Internal.Property (assert, (===))
 import           Hedgehog.Internal.Property (discard, failure, success)
 import           Hedgehog.Internal.Property (DiscardLimit, withDiscards)
+import           Hedgehog.Internal.Property (evaluate)
 import           Hedgehog.Internal.Property (footnote, footnoteShow)
 import           Hedgehog.Internal.Property (forAll, forAllWith)
 import           Hedgehog.Internal.Property (liftCatch, liftCatchIO, liftEither, liftExceptT)

--- a/hedgehog/src/Hedgehog/Internal/Exception.hs
+++ b/hedgehog/src/Hedgehog/Internal/Exception.hs
@@ -1,42 +1,23 @@
 module Hedgehog.Internal.Exception (
-    TypedException(..)
-  , tryAll
+    tryAll
+  , tryEvaluate
   ) where
 
-import           Control.Exception (Exception(..), AsyncException, SomeException(..))
+import           Control.Exception (Exception(..), AsyncException, SomeException(..), evaluate)
 import           Control.Monad.Catch (MonadCatch(..), throwM)
 
-import           Data.Typeable (typeOf)
+import           System.IO.Unsafe (unsafePerformIO)
 
 
--- | Newtype for 'SomeException' with a 'Show' instance that only contains
---   valid Haskell 98 tokens and also includes the type of the exception.
---
---   For example, when catching the exception thrown by @fail "foo" :: IO ()@
---   and calling show:
---
--- @
---   IOException "user error (foo)"
--- @
---
---   Having access to the type can be useful when trying to track down the
---   source of an exception.
---
-newtype TypedException =
-  TypedException SomeException
-
-instance Show TypedException where
-  showsPrec p (TypedException (SomeException x)) =
-    showParen (p > 10) $
-      showsPrec 11 (typeOf x) .
-      showChar ' ' .
-      showsPrec 11 (displayException x)
-
-tryAll :: MonadCatch m => m a -> m (Either TypedException a)
+tryAll :: MonadCatch m => m a -> m (Either SomeException a)
 tryAll m =
   catch (fmap Right m) $ \exception ->
     case fromException exception :: Maybe AsyncException of
       Nothing ->
-        pure . Left $ TypedException exception
+        pure $ Left exception
       Just async ->
         throwM async
+
+tryEvaluate :: a -> Either SomeException a
+tryEvaluate x =
+  unsafePerformIO (tryAll (evaluate x))

--- a/hedgehog/src/Hedgehog/Internal/Queue.hs
+++ b/hedgehog/src/Hedgehog/Internal/Queue.hs
@@ -6,7 +6,7 @@ module Hedgehog.Internal.Queue (
 
   , runTasks
   , finalizeTask
- 
+
   , runActiveFinalizers
   , dequeueMVar
 

--- a/hedgehog/src/Hedgehog/Internal/Region.hs
+++ b/hedgehog/src/Hedgehog/Internal/Region.hs
@@ -10,7 +10,7 @@ module Hedgehog.Internal.Region (
   , finishRegion
   ) where
 
-import           Control.Concurrent.STM (STM, TVar, atomically)
+import           Control.Concurrent.STM (STM, TVar)
 import qualified Control.Concurrent.STM.TMVar as TMVar
 import qualified Control.Concurrent.STM.TVar as TVar
 import           Control.Monad.Catch (MonadMask(..), bracket)
@@ -20,22 +20,27 @@ import           System.Console.Regions (ConsoleRegion, RegionLayout(..), LiftRe
 import qualified System.Console.Regions as Console
 
 
+data Content =
+    Empty
+  | Open ConsoleRegion
+  | Closed
+
 newtype Region =
   Region {
-      unRegion :: TVar (Maybe ConsoleRegion)
+      unRegion :: TVar Content
     }
 
 newEmptyRegion :: LiftRegion m => m Region
 newEmptyRegion =
   liftRegion $ do
-    ref <- TVar.newTVar Nothing
+    ref <- TVar.newTVar Empty
     pure $ Region ref
 
 newRegion :: LiftRegion m => m Region
 newRegion =
   liftRegion $ do
     region <- Console.openConsoleRegion Linear
-    ref <- TVar.newTVar $ Just region
+    ref <- TVar.newTVar $ Open region
     pure $ Region ref
 
 forceRegion :: LiftRegion m => Region -> String -> m ()
@@ -43,36 +48,33 @@ forceRegion (Region var) content =
   liftRegion $ do
     mregion <- TVar.readTVar var
     case mregion of
-      Nothing -> do
+      Empty -> do
         region <- Console.openConsoleRegion Linear
-        TVar.writeTVar var $ Just region
+        TVar.writeTVar var $ Open region
         Console.setConsoleRegion region content
 
-      Just region ->
+      Open region ->
         Console.setConsoleRegion region content
+
+      Closed ->
+        pure ()
 
 setRegion :: LiftRegion m => Region -> String -> m ()
 setRegion (Region var) content =
   liftRegion $ do
     mregion <- TVar.readTVar var
     case mregion of
-      Nothing -> do
+      Empty ->
         pure ()
 
-      Just region ->
+      Open region ->
         Console.setConsoleRegion region content
 
-displayRegions :: (MonadIO m, MonadMask m) => m a -> m a
-displayRegions io = do
-  liftIO . atomically $ do
-    -- clear old regions
-    mxs <- TMVar.tryTakeTMVar Console.regionList
-    case mxs of
-      Nothing ->
+      Closed ->
         pure ()
-      Just _xs ->
-        TMVar.putTMVar Console.regionList []
 
+displayRegions :: (MonadIO m, MonadMask m) => m a -> m a
+displayRegions io =
   Console.displayConsoleRegions io
 
 displayRegion ::
@@ -84,27 +86,42 @@ displayRegion ::
 displayRegion =
   displayRegions . bracket newRegion finishRegion
 
-moveToBottom :: ConsoleRegion -> STM ()
-moveToBottom region = do
-  mxs <- TMVar.tryTakeTMVar Console.regionList
-  case mxs of
-    Nothing ->
-      pure ()
-    Just xs0 ->
-      let
-        xs1 =
-          filter (/= region) xs0
-      in
-        TMVar.putTMVar Console.regionList (region : xs1)
+moveToBottom :: Region -> STM ()
+moveToBottom (Region var) =
+  liftRegion $ do
+    mregion <- TVar.readTVar var
+    case mregion of
+      Empty ->
+        pure ()
+
+      Open region -> do
+        mxs <- TMVar.tryTakeTMVar Console.regionList
+        case mxs of
+          Nothing ->
+            pure ()
+
+          Just xs0 ->
+            let
+              xs1 =
+                filter (/= region) xs0
+            in
+              TMVar.putTMVar Console.regionList (region : xs1)
+
+      Closed ->
+        pure ()
 
 finishRegion :: LiftRegion m => Region -> m ()
 finishRegion (Region var) =
   liftRegion $ do
     mregion <- TVar.readTVar var
     case mregion of
-      Nothing ->
-        pure ()
+      Empty -> do
+        TVar.writeTVar var Closed
 
-      Just region -> do
+      Open region -> do
         content <- Console.getConsoleRegion region
         Console.finishConsoleRegion region content
+        TVar.writeTVar var Closed
+
+      Closed ->
+        pure ()


### PR DESCRIPTION
This adds the `evaluate :: a -> Test m a` function which will evaluate its argument and fail the test if doing so throws an exception. I have updated `assert` and `(===)` to both make use of this, so exceptions thrown from pure code should now be reported properly.

This fixes #57 and addresses an issue @tmcdonell raised IRL.

Sorry for the potentially misleading title @erikd, this does not solve #84.

<img width="816" alt="screen shot 2017-07-02 at 10 33 32 am" src="https://user-images.githubusercontent.com/134805/27766416-3ba58288-5f12-11e7-915d-113bf9ad3fc6.png">

