### PR TITLE
Use haddock not-home option for internals

### DIFF
--- a/hedgehog/src/Hedgehog/Internal/Config.hs
+++ b/hedgehog/src/Hedgehog/Internal/Config.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK not-home #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DoAndIfThenElse #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}

--- a/hedgehog/src/Hedgehog/Internal/Discovery.hs
+++ b/hedgehog/src/Hedgehog/Internal/Discovery.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK not-home #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE LambdaCase #-}
 module Hedgehog.Internal.Discovery (

--- a/hedgehog/src/Hedgehog/Internal/Distributive.hs
+++ b/hedgehog/src/Hedgehog/Internal/Distributive.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK not-home #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE TypeOperators #-}

--- a/hedgehog/src/Hedgehog/Internal/Exception.hs
+++ b/hedgehog/src/Hedgehog/Internal/Exception.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK not-home #-}
 module Hedgehog.Internal.Exception (
     tryAll
   , tryEvaluate

--- a/hedgehog/src/Hedgehog/Internal/Gen.hs
+++ b/hedgehog/src/Hedgehog/Internal/Gen.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK not-home #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveFunctor #-}

--- a/hedgehog/src/Hedgehog/Internal/HTraversable.hs
+++ b/hedgehog/src/Hedgehog/Internal/HTraversable.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK not-home #-}
 {-# LANGUAGE RankNTypes #-}
 module Hedgehog.Internal.HTraversable (
     HTraversable(..)

--- a/hedgehog/src/Hedgehog/Internal/Opaque.hs
+++ b/hedgehog/src/Hedgehog/Internal/Opaque.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK not-home #-}
 module Hedgehog.Internal.Opaque (
     Opaque(..)
   ) where

--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK not-home #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DoAndIfThenElse #-}

--- a/hedgehog/src/Hedgehog/Internal/Queue.hs
+++ b/hedgehog/src/Hedgehog/Internal/Queue.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK not-home #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 module Hedgehog.Internal.Queue (

--- a/hedgehog/src/Hedgehog/Internal/Range.hs
+++ b/hedgehog/src/Hedgehog/Internal/Range.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK not-home #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Hedgehog.Internal.Range (
   -- * Size

--- a/hedgehog/src/Hedgehog/Internal/Region.hs
+++ b/hedgehog/src/Hedgehog/Internal/Region.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK not-home #-}
 module Hedgehog.Internal.Region (
     Region(..)
   , newEmptyRegion

--- a/hedgehog/src/Hedgehog/Internal/Report.hs
+++ b/hedgehog/src/Hedgehog/Internal/Report.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK not-home #-}
 {-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveTraversable #-}

--- a/hedgehog/src/Hedgehog/Internal/Runner.hs
+++ b/hedgehog/src/Hedgehog/Internal/Runner.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK not-home #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DoAndIfThenElse #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}

--- a/hedgehog/src/Hedgehog/Internal/Seed.hs
+++ b/hedgehog/src/Hedgehog/Internal/Seed.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK not-home #-}
 {-# LANGUAGE CPP #-}
 -- |
 -- This is a port of "Fast Splittable Pseudorandom Number Generators" by Steele

--- a/hedgehog/src/Hedgehog/Internal/Show.hs
+++ b/hedgehog/src/Hedgehog/Internal/Show.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK not-home #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE PatternGuards #-}
 module Hedgehog.Internal.Show (

--- a/hedgehog/src/Hedgehog/Internal/Shrink.hs
+++ b/hedgehog/src/Hedgehog/Internal/Shrink.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK not-home #-}
 module Hedgehog.Internal.Shrink (
     towards
   , towardsFloat

--- a/hedgehog/src/Hedgehog/Internal/Source.hs
+++ b/hedgehog/src/Hedgehog/Internal/Source.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK not-home #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}

--- a/hedgehog/src/Hedgehog/Internal/State.hs
+++ b/hedgehog/src/Hedgehog/Internal/State.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK not-home #-}
 {-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveTraversable #-}

--- a/hedgehog/src/Hedgehog/Internal/TH.hs
+++ b/hedgehog/src/Hedgehog/Internal/TH.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK not-home #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TemplateHaskell #-}
 module Hedgehog.Internal.TH (

--- a/hedgehog/src/Hedgehog/Internal/Tree.hs
+++ b/hedgehog/src/Hedgehog/Internal/Tree.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK not-home #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}

--- a/hedgehog/src/Hedgehog/Internal/Tripping.hs
+++ b/hedgehog/src/Hedgehog/Internal/Tripping.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK not-home #-}
 module Hedgehog.Internal.Tripping (
     tripping
   ) where


### PR DESCRIPTION
At the moment, clicking around on Haddock references to the public API leads you into the internal modules.

The `not-home` option makes Haddock link to the public API for publicly exported identifiers. It still links to the internals for things that aren't otherwise exported.