### PR TITLE
Support for using QuickCheck generators in Hedgehog and vice versa

### DIFF
--- a/hedgehog-example/hedgehog-example.cabal
+++ b/hedgehog-example/hedgehog-example.cabal
@@ -42,6 +42,7 @@ test-suite test
 
   build-depends:
       hedgehog
+    , hedgehog-quickcheck
     , base                            >= 3          && < 5
     , containers                      >= 0.4        && < 0.6
     , filepath                        >= 1.3        && < 1.4
@@ -51,6 +52,7 @@ test-suite test
     , parsec                          >= 3.1        && < 3.2
     , pretty-show                     >= 1.6        && < 1.7
     , process                         >= 1.2        && < 1.7
+    , QuickCheck                      >= 2.7        && < 2.11
     , resourcet                       >= 1.1        && < 1.2
     , temporary-resourcet             >= 0.1        && < 0.2
     , text                            >= 1.1        && < 1.3

--- a/hedgehog-example/hedgehog-example.cabal
+++ b/hedgehog-example/hedgehog-example.cabal
@@ -1,7 +1,7 @@
+version: 0
+
 name:
   hedgehog-example
-version:
-  0
 license:
   BSD3
 author:

--- a/hedgehog-example/test/Test/Example/QuickCheck.hs
+++ b/hedgehog-example/test/Test/Example/QuickCheck.hs
@@ -1,0 +1,27 @@
+--
+-- An example of using QuickCheck generators inside Hedgehog.
+--
+{-# LANGUAGE TemplateHaskell #-}
+module Test.Example.QuickCheck where
+
+import           Hedgehog
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Gen.QuickCheck as Gen
+import qualified Hedgehog.Range as Range
+
+
+prop_reverse :: Property
+prop_reverse =
+  property $ do
+    xs <- forAll (Gen.arbitrary :: Gen [Int])
+    reverse (reverse xs) === xs
+
+prop_reverse_mixed :: Property
+prop_reverse_mixed =
+  property $ do
+    xs <- forAll $ Gen.list (Range.linear 0 100) (Gen.arbitrary :: Gen Char)
+    reverse (reverse xs) === xs
+
+tests :: IO Bool
+tests =
+  checkParallel $$(discover)

--- a/hedgehog-example/test/test.hs
+++ b/hedgehog-example/test/test.hs
@@ -2,6 +2,7 @@ import           System.IO (BufferMode(..), hSetBuffering, stdout, stderr)
 
 import qualified Test.Example.Basic as Test.Example.Basic
 import qualified Test.Example.Exception as Test.Example.Exception
+import qualified Test.Example.QuickCheck as Test.Example.QuickCheck
 import qualified Test.Example.References as Test.Example.References
 import qualified Test.Example.Registry as Test.Example.Registry
 import qualified Test.Example.Resource as Test.Example.Resource
@@ -16,6 +17,7 @@ main = do
   _results <- sequence [
       Test.Example.Basic.tests
     , Test.Example.Exception.tests
+    , Test.Example.QuickCheck.tests
     , Test.Example.References.tests
     , Test.Example.Registry.tests
     , Test.Example.Resource.tests

--- a/hedgehog-quickcheck/CHANGELOG.md
+++ b/hedgehog-quickcheck/CHANGELOG.md
@@ -1,0 +1,9 @@
+## Version 0.1 (2017-07-16)
+
+- Initial release ([#103][103], [@jystic][jystic])
+
+[jystic]:
+  https://github.com/jystic
+
+[103]:
+  https://github.com/hedgehogqa/haskell-hedgehog/pull/103

--- a/hedgehog-quickcheck/LICENSE
+++ b/hedgehog-quickcheck/LICENSE
@@ -1,0 +1,29 @@
+Copyright 2017, Jacob Stanley
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+  1. Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+  3. Neither the name of the copyright holder nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/hedgehog-quickcheck/README.md
+++ b/hedgehog-quickcheck/README.md
@@ -1,0 +1,57 @@
+hedgehog-quickcheck [![Hackage][hackage-shield]][hackage]
+===================
+
+> Hedgehog will eat all your bugs.
+
+<img src="https://github.com/hedgehogqa/haskell-hedgehog/raw/master/img/hedgehog-logo.png" width="307" align="right"/>
+
+Use [QuickCheck](http://hackage.haskell.org/package/QuickCheck) generators in [Hedgehog](http://hedgehog.qa/) and vice versa.
+
+## Example
+
+The [Hedgehog.Gen.QuickCheck][haddock-hedgehog-gen-quickcheck] module
+allows the use of QuickCheck generators inside Hedgehog.
+
+```hs
+{-# LANGUAGE TemplateHaskell #-}
+
+import           Hedgehog
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Gen.QuickCheck as Gen
+import qualified Hedgehog.Range as Range
+```
+
+Once you have your imports set up, you can write a property which mixes
+QuickCheck and Hedgehog generators together:
+
+```hs
+prop_reverse :: Property
+prop_reverse =
+  property $ do
+    xs <- forAll $ Gen.list (Range.linear 0 100) (Gen.arbitrary :: Gen Char)
+    reverse (reverse xs) === xs
+```
+
+And add the Template Haskell splice which will discover your properties:
+
+```hs
+tests :: IO Bool
+tests =
+  checkParallel $$(discover)
+```
+
+You can then load the module in GHCi, and run it:
+
+```
+λ tests
+━━━ Test.Example ━━━
+  ✓ prop_reverse passed 100 tests.
+```
+
+[hackage]:
+  http://hackage.haskell.org/package/hedgehog-quickcheck
+[hackage-shield]:
+  https://img.shields.io/hackage/v/hedgehog-quickcheck.svg
+
+[haddock-hedgehog-gen-quickcheck]:
+  http://hackage.haskell.org/package/hedgehog-quickcheck/docs/Hedgehog-Gen-QuickCheck.html

--- a/hedgehog-quickcheck/hedgehog-quickcheck.cabal
+++ b/hedgehog-quickcheck/hedgehog-quickcheck.cabal
@@ -1,0 +1,58 @@
+version: 0.1
+
+name:
+  hedgehog-quickcheck
+license:
+  BSD3
+author:
+  Jacob Stanley
+maintainer:
+  Jacob Stanley <jacob@stanley.io>
+homepage:
+  https://hedgehog.qa
+bug-reports:
+  https://github.com/hedgehogqa/haskell-hedgehog/issues
+synopsis:
+  Use QuickCheck generators in Hedgehog and vice versa.
+description:
+  Use QuickCheck generators in Hedgehog and vice versa.
+category:
+  Testing
+license:
+  BSD3
+license-file:
+  LICENSE
+cabal-version:
+  >= 1.8
+build-type:
+  Simple
+tested-with:
+    GHC == 7.10.2
+  , GHC == 7.10.3
+  , GHC == 8.0.1
+  , GHC == 8.0.2
+extra-source-files:
+  README.md
+  CHANGELOG.md
+
+source-repository head
+  type: git
+  location: git://github.com/hedgehogqa/haskell-hedgehog.git
+
+library
+  build-depends:
+      base                            >= 3          && < 5
+    , hedgehog                        >= 0.5        && < 0.6
+    , QuickCheck                      >= 2.7        && < 2.11
+    , transformers                    >= 0.4        && < 0.6
+
+  ghc-options:
+    -Wall
+
+  hs-source-dirs:
+    src
+
+  exposed-modules:
+    Hedgehog.Gen.QuickCheck
+
+    Test.QuickCheck.Hedgehog

--- a/hedgehog-quickcheck/src/Hedgehog/Gen/QuickCheck.hs
+++ b/hedgehog-quickcheck/src/Hedgehog/Gen/QuickCheck.hs
@@ -1,0 +1,42 @@
+-- | Use QuickCheck generators and 'QuickCheck.Arbitrary' instances with Hedgehog.
+--
+module Hedgehog.Gen.QuickCheck (
+    arbitrary
+  , quickcheck
+  ) where
+
+import           Hedgehog
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+import qualified Test.QuickCheck as QuickCheck
+import qualified Test.QuickCheck.Gen as QuickCheck
+import qualified Test.QuickCheck.Random as QuickCheck
+
+
+seedQCGen :: MonadGen m => m QuickCheck.QCGen
+seedQCGen =
+  QuickCheck.mkQCGen <$> Gen.lift (Gen.integral_ Range.constantBounded)
+
+-- | Create a Hedgehog 'Gen' from a QuickCheck 'QuickCheck.Gen'.
+--
+--   By default the 'Gen' created will not have any shrinking, you can use
+--   @Gen.@'Gen.shrink' if you have a shrink function which you would like to
+--   apply.
+--
+quickcheck :: MonadGen m => QuickCheck.Gen a -> m a
+quickcheck (QuickCheck.MkGen gen) =
+  Gen.sized $ \size -> do
+    qcg <- seedQCGen
+    pure $
+      gen qcg (fromIntegral size)
+
+-- | Create a Hedgehog 'Gen' from a QuickCheck 'QuickCheck.Arbitrary' instance.
+--
+--   The Arbitrary's 'QuickCheck.shrink' function is used to provide shrinking
+--   for the Hedgehog 'Gen'.
+--
+arbitrary :: (QuickCheck.Arbitrary a, MonadGen m) => m a
+arbitrary =
+  Gen.shrink QuickCheck.shrink $
+    quickcheck QuickCheck.arbitrary

--- a/hedgehog-quickcheck/src/Test/QuickCheck/Hedgehog.hs
+++ b/hedgehog-quickcheck/src/Test/QuickCheck/Hedgehog.hs
@@ -1,0 +1,42 @@
+-- | Use Hedgehog generators with QuickCheck.
+--
+module Test.QuickCheck.Hedgehog (
+    hedgehog
+  ) where
+
+import           Control.Monad.Trans.Maybe (runMaybeT)
+import           Data.Functor.Identity (runIdentity)
+
+import           Hedgehog
+import           Hedgehog.Internal.Gen (runGenT)
+import qualified Hedgehog.Internal.Seed as Seed
+import           Hedgehog.Internal.Tree (Tree(..), Node(..))
+
+import qualified Test.QuickCheck as QuickCheck
+
+
+genSeed :: QuickCheck.Gen Seed
+genSeed =
+  Seed.from <$> QuickCheck.arbitraryBoundedIntegral
+
+-- | Create a QuickCheck 'QuickCheck.Gen' from a Hedgehog 'Gen'.
+--
+--   /Note that this conversion does not preserve shrinking. There is currently/
+--   /no way to use Hedgehog's shrinking capability inside QuickCheck./
+--
+hedgehog :: Gen a -> QuickCheck.Gen a
+hedgehog gen =
+  let
+    loop n =
+      if n <= 0 then
+        QuickCheck.discard
+      else do
+        seed <- genSeed
+        size <- QuickCheck.sized (pure . fromIntegral)
+        case runIdentity . runMaybeT . runTree $ runGenT size seed gen of
+          Nothing ->
+            loop (n - 1)
+          Just x ->
+            pure $ nodeValue x
+  in
+    loop (100 :: Int)

--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -1,7 +1,7 @@
+version: 0.5
+
 name:
   hedgehog
-version:
-  0.5
 license:
   BSD3
 author:


### PR DESCRIPTION
This allows the use of QuickCheck generators and Arbitrary instances in Hedgehog, and also the use of Hedgehog generators inside QuickCheck.

Unfortunately I can't think of a way to get shrinking when using Hedgehog generators inside QuickCheck, but the other way is possible.