### PR TITLE
Add mapTestT operator.

### DIFF
--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -451,9 +451,9 @@ runTest :: Test a -> (Either Failure a, [Log])
 runTest =
   runIdentity . runTestT
 
-mapTestT :: (forall b. m b -> n b) -> TestT m a -> TestT n a
+mapTestT :: Monad m => (b -> m a) -> TestT m b -> TestT m a
 mapTestT f =
-  mkTestT . f . runTestT
+  mkTestT . (=<<) (\(e, l) -> fmap (flip (,) l) $ traverse f e) . runTestT
 
 -- | Log some information which might be relevant to a potential test failure.
 --

--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -75,6 +75,7 @@ module Hedgehog.Internal.Property (
   , mkTestT
   , runTest
   , runTestT
+  , mapTestT
   ) where
 
 import           Control.Applicative (Alternative(..))
@@ -449,6 +450,10 @@ runTestT =
 runTest :: Test a -> (Either Failure a, [Log])
 runTest =
   runIdentity . runTestT
+
+mapTestT :: (forall b. m b -> n b) -> TestT m a -> TestT n a
+mapTestT f =
+  mkTestT . f . runTestT
 
 -- | Log some information which might be relevant to a potential test failure.
 --


### PR DESCRIPTION
cc @charleso @jystic 

Needed this operator for writing some amazonka IO tests, unfortunately the code is internal Ambiata right now but the general pattern is
```haskell
prop_standard_api_no_duplicates = property $ do
  test . mapTestT runAWSDefaultRegion $ do
    env <- lift testAWSEnv
    # Run amazonka things
    # assert using (===)

```