### PR TITLE
Simplify dependency on semigroups.

### DIFF
--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -60,6 +60,7 @@ library
     , primitive                       >= 0.6        && < 0.7
     , random                          >= 1.1        && < 1.2
     , resourcet                       >= 1.1        && < 1.2
+    , semigroups                      >= 0.16       && < 0.19
     , stm                             >= 2.4        && < 2.5
     , template-haskell                >= 2.10       && < 2.13
     , text                            >= 1.1        && < 1.3
@@ -68,10 +69,6 @@ library
     , transformers                    >= 0.5        && < 0.6
     , transformers-base               >= 0.4        && < 0.5
     , wl-pprint-annotated             >= 0.0        && < 0.2
-
-  if impl(ghc < 8.0)
-    build-depends:
-      semigroups                      >= 0.16       && < 0.19
 
   if !os(windows)
     build-depends:
@@ -133,7 +130,4 @@ test-suite test
     , pretty-show                     >= 1.6        && < 1.7
     , text                            >= 1.1        && < 1.3
     , transformers                    >= 0.3        && < 0.6
-
-  if impl(ghc < 8.0)
-    build-depends:
-      semigroups                      >= 0.16       && < 0.19
+    , semigroups                      >= 0.16       && < 0.19


### PR DESCRIPTION
There's no need to exclude the package on older GHC versions. The package itself
does this with CPP.