### PR TITLE
Added a /== operator to express that 2 values must be different

### DIFF
--- a/hedgehog-example/src/Test/Example/Basic.hs
+++ b/hedgehog-example/src/Test/Example/Basic.hs
@@ -253,6 +253,12 @@ prop_record =
     y <- forAll genRecord
     x === y
 
+prop_different_record :: Property
+prop_different_record =
+  property $ do
+    x <- forAll genRecord
+    x /== x
+
 ------------------------------------------------------------------------
 -- Example 6 - Text.takeEnd
 

--- a/hedgehog/src/Hedgehog.hs
+++ b/hedgehog/src/Hedgehog.hs
@@ -98,6 +98,7 @@ module Hedgehog (
   , failure
   , assert
   , (===)
+  , (/==)
   , tripping
 
   , eval
@@ -146,7 +147,7 @@ import           Hedgehog.Internal.Gen (Gen, GenT, MonadGen(..))
 import           Hedgehog.Internal.HTraversable (HTraversable(..))
 import           Hedgehog.Internal.Opaque (Opaque(..))
 import           Hedgehog.Internal.Property (annotate, annotateShow)
-import           Hedgehog.Internal.Property (assert, (===))
+import           Hedgehog.Internal.Property (assert, (===), (/==))
 import           Hedgehog.Internal.Property (discard, failure, success)
 import           Hedgehog.Internal.Property (DiscardLimit, withDiscards)
 import           Hedgehog.Internal.Property (eval, evalM, evalIO)

--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -55,6 +55,7 @@ module Hedgehog.Internal.Property (
   , success
   , assert
   , (===)
+  , (/==)
 
   , eval
   , evalM
@@ -551,6 +552,22 @@ infix 4 ===
     success
   else
     withFrozenCallStack $ failDiff x y
+
+infix 4 /==
+
+-- | Fails the test if the two arguments provided are equal.
+--
+(/==) :: (MonadTest m, Eq a, Show a, HasCallStack) => a -> a -> m ()
+(/==) x y = do
+  ok <- withFrozenCallStack $ eval (x /= y)
+  if ok then
+    success
+  else
+    withFrozenCallStack $
+      failWith Nothing $ unlines [
+          "━━━ Both equal to ━━━"
+        , showPretty x
+        ]
 
 -- | Fails the test if the value throws an exception when evaluated to weak
 --   head normal form (WHNF).


### PR DESCRIPTION
Hi @thumphries, @jystic, here is a proposal for a `/==` operator. 

Hmm I can see that stylish-haskell has made the diff larger than it should. Do you have any specific formatting rules?