### PR TITLE
Depend on `semigroups`

### DIFF
--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -128,9 +128,6 @@ test-suite test
     , base                            >= 3          && < 5
     , containers                      >= 0.4        && < 0.6
     , pretty-show                     >= 1.6        && < 1.7
+    , semigroups                      >= 0.16       && < 0.19
     , text                            >= 1.1        && < 1.3
     , transformers                    >= 0.3        && < 0.6
-
-  if impl(ghc < 8.0)
-    build-depends:
-      semigroups                      >= 0.16       && < 0.19

--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -60,6 +60,7 @@ library
     , primitive                       >= 0.6        && < 0.7
     , random                          >= 1.1        && < 1.2
     , resourcet                       >= 1.1        && < 1.2
+    , semigroups                      >= 0.16       && < 0.19
     , stm                             >= 2.4        && < 2.5
     , template-haskell                >= 2.10       && < 2.13
     , text                            >= 1.1        && < 1.3
@@ -68,10 +69,6 @@ library
     , transformers                    >= 0.5        && < 0.6
     , transformers-base               >= 0.4        && < 0.5
     , wl-pprint-annotated             >= 0.0        && < 0.2
-
-  if impl(ghc < 8.0)
-    build-depends:
-      semigroups                      >= 0.16       && < 0.19
 
   if !os(windows)
     build-depends:


### PR DESCRIPTION
Conditional dependency on `semigroups` causes some problems for tools that don't know now to deal with `if`s in cabal files. I can't build `hegdgehog` on the `ghc7102` or `ghc7103` package sets, because the tools don't know how to account for the conditional dependency. It's okay to just always depend on semigroups - see https://qfpl.io/posts/semigroups/

Please [squash this PR](https://help.github.com/articles/about-pull-request-merges/#squash-and-merge-your-pull-request-commits) when you merge it :)