### PR TITLE
Add GHC 8.4.1 as an allowed failure to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,10 @@ matrix:
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-1.24,ghc-8.0.2], sources: [hvr-ghc]}}
     - compiler: "ghc-8.2.2"
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-1.24,ghc-8.2.2], sources: [hvr-ghc]}}
+    - compiler: "ghc-8.4.1"
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.0,ghc-8.4.1], sources: [hvr-ghc]}}
+  allow_failures:
+    - compiler: "ghc-8.4.1"
 
 before_install:
  - unset CC


### PR DESCRIPTION
We should prepare for the quickly approaching GHC 8.4 release. This adds the pre-release version to travis, but as an allowed failure for now.