### PR TITLE
Bump dependency on ansi-terminal

### DIFF
--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -46,7 +46,7 @@ source-repository head
 library
   build-depends:
       base                            >= 3          && < 5
-    , ansi-terminal                   >= 0.6        && < 0.8
+    , ansi-terminal                   >= 0.6        && < 0.9
     , async                           >= 2.0        && < 2.2
     , bytestring                      >= 0.10       && < 0.11
     , concurrent-output               >= 1.7        && < 1.11


### PR DESCRIPTION
changelog: https://hackage.haskell.org/package/ansi-terminal-0.8.0.1/changelog