### PR TITLE
Cabal.project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .cabal-sandbox/
 cabal.sandbox.config
+cabal.project.local
 dist/
+dist-newstyle/

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,5 @@
+packages:
+  hedgehog
+  hedgehog-example
+  hedgehog-quickcheck
+


### PR DESCRIPTION
This lets you build all three packages from the top level with `cabal new-build all`
I've also added the new-build artifacts to the .gitignore