### PR TITLE
Bump upper bounds for template-haskell and resourcet

### DIFF
--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -65,7 +65,7 @@ library
     , resourcet                       >= 1.1        && < 1.2
     , semigroups                      >= 0.16       && < 0.19
     , stm                             >= 2.4        && < 2.5
-    , template-haskell                >= 2.10       && < 2.13
+    , template-haskell                >= 2.10       && < 2.14
     , text                            >= 1.1        && < 1.3
     , th-lift                         >= 0.7        && < 0.8
     , time                            >= 1.4        && < 1.9

--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -62,7 +62,7 @@ library
     , pretty-show                     >= 1.6        && < 1.7
     , primitive                       >= 0.6        && < 0.7
     , random                          >= 1.1        && < 1.2
-    , resourcet                       >= 1.1        && < 1.2
+    , resourcet                       >= 1.1        && < 1.3
     , semigroups                      >= 0.16       && < 0.19
     , stm                             >= 2.4        && < 2.5
     , template-haskell                >= 2.10       && < 2.14


### PR DESCRIPTION
- `template-haskell` is at `2.13` in GHC 8.4
- `resourcet` `1.2.0` was released the other day

We should be good for 8.4 after this, will aim for a point release

@nhibberd @gwils 