### PR TITLE
Add Semigroup and Monoid instances for GenT that lift the inner Monoid

### DIFF
--- a/hedgehog/src/Hedgehog/Internal/Gen.hs
+++ b/hedgehog/src/Hedgehog/Internal/Gen.hs
@@ -153,7 +153,7 @@ module Hedgehog.Internal.Gen (
   , renderNodes
   ) where
 
-import           Control.Applicative (Alternative(..))
+import           Control.Applicative (Alternative(..),liftA2)
 import           Control.Monad (MonadPlus(..), filterM, replicateM, ap, join)
 import           Control.Monad.Base (MonadBase(..))
 import           Control.Monad.Catch (MonadThrow(..), MonadCatch(..))
@@ -190,6 +190,8 @@ import qualified Data.List.NonEmpty as NonEmpty
 import           Data.Map (Map)
 import qualified Data.Map as Map
 import qualified Data.Maybe as Maybe
+import           Data.Semigroup (Semigroup)
+import qualified Data.Semigroup as Semigroup
 import           Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
 import           Data.Set (Set)
@@ -521,6 +523,16 @@ instance (MonadGen m, Monoid w) => MonadGen (Strict.RWST r w s m) where
 
 ------------------------------------------------------------------------
 -- GenT instances
+
+-- technically, the Monoid constraint on @a@ could be weakened
+-- to Semigroup, but this would be annoying for older GHCs
+-- where Semigroup is not a superclass of Monoid.
+instance (Monad m, Monoid a) => Semigroup (GenT m a) where
+  (<>) = liftA2 mappend
+
+instance (Monad m, Monoid a) => Monoid (GenT m a) where
+  mappend = (Semigroup.<>)
+  mempty = return mempty
 
 instance Functor m => Functor (GenT m) where
   fmap f gen =

--- a/hedgehog/src/Hedgehog/Internal/Gen.hs
+++ b/hedgehog/src/Hedgehog/Internal/Gen.hs
@@ -524,14 +524,11 @@ instance (MonadGen m, Monoid w) => MonadGen (Strict.RWST r w s m) where
 ------------------------------------------------------------------------
 -- GenT instances
 
--- technically, the Monoid constraint on @a@ could be weakened
--- to Semigroup, but this would be annoying for older GHCs
--- where Semigroup is not a superclass of Monoid.
-instance (Monad m, Monoid a) => Semigroup (GenT m a) where
-  (<>) = liftA2 mappend
+instance (Monad m, Semigroup a) => Semigroup (GenT m a) where
+  (<>) = liftA2 (Semigroup.<>)
 
 instance (Monad m, Monoid a) => Monoid (GenT m a) where
-  mappend = (Semigroup.<>)
+  mappend = liftA2 mappend
   mempty = return mempty
 
 instance Functor m => Functor (GenT m) where


### PR DESCRIPTION
This uses the technique suggested in [Equational Reasoning at Scale](http://www.haskellforall.com/2014/07/equational-reasoning-at-scale.html) to provide a `Monoid` instance for `GenT`. This was motivated by more than just theoretical concerns. At work, I was recently in a situation where I needed to flatten a list of generators like this:

    flatten :: [Gen ByteString] -> Gen ByteString

With the instances provided by this PR, `flatten` is just `mconcat`. I've written these instances so that they should be compatible with all phases Semigroup-Monoid-Proposal that are represented by GHC 8.4 and lower.