### PR TITLE
Generators for UTCTime and ZonedTime

### DIFF
--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -72,6 +72,8 @@ library
     , transformers                    >= 0.4        && < 0.6
     , transformers-base               >= 0.4        && < 0.5
     , wl-pprint-annotated             >= 0.0        && < 0.2
+    , time                            >= 1.8.0.2
+    , tz                              >= 0.1.3.0
 
   if !os(windows)
     build-depends:

--- a/hedgehog/src/Hedgehog/Gen.hs
+++ b/hedgehog/src/Hedgehog/Gen.hs
@@ -60,6 +60,10 @@ module Hedgehog.Gen (
   , utf8
   , bytes
 
+  -- ** Time
+  , genUTCTime
+  , genZonedTime
+
   -- ** Choice
   , constant
   , element


### PR DESCRIPTION
Hello,

I've found those generators useful to me and thought I would share them. I had to add dependencies on the `time` and `tz` packages. The former is where the data structures of `UTCTime` and `ZonedTime` come from and the latter enumerates all the time zones.