### PR TITLE
Move async and lifted-async bounds

### DIFF
--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -49,13 +49,13 @@ library
   build-depends:
       base                            >= 3          && < 5
     , ansi-terminal                   >= 0.6        && < 0.9
-    , async                           >= 2.0        && < 2.2
+    , async                           >= 2.0        && < 2.3
     , bytestring                      >= 0.10       && < 0.11
     , concurrent-output               >= 1.7        && < 1.11
     , containers                      >= 0.4        && < 0.6
     , directory                       >= 1.2        && < 1.4
     , exceptions                      >= 0.7        && < 0.9
-    , lifted-async                    >= 0.7        && < 0.10
+    , lifted-async                    >= 0.7        && < 0.11
     , mmorph                          >= 1.0        && < 1.2
     , monad-control                   >= 1.0        && < 1.1
     , mtl                             >= 2.1        && < 2.3


### PR DESCRIPTION
so that async 2.2.* can be used.