### PR TITLE
.travis.yml: DIsallow failures with ghc 8.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,11 +47,7 @@ matrix:
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.2], sources: [hvr-ghc]}}
     - compiler: "ghc-8.4.1"
-      env: GHCHEAD=true
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
-
-  allow_failures:
-    - compiler: "ghc-8.4.1"
 
 before_install:
   - HC=${CC}


### PR DESCRIPTION
Ghc 8.4 has now had an official release so the build should succeed.
