### PR TITLE
Bump upper bound for exceptions to 0.11

### DIFF
--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -54,7 +54,7 @@ library
     , concurrent-output               >= 1.7        && < 1.11
     , containers                      >= 0.4        && < 0.6
     , directory                       >= 1.2        && < 1.4
-    , exceptions                      >= 0.7        && < 0.9
+    , exceptions                      >= 0.7        && < 0.11
     , lifted-async                    >= 0.7        && < 0.11
     , mmorph                          >= 1.0        && < 1.2
     , monad-control                   >= 1.0        && < 1.1


### PR DESCRIPTION
This will compile ok when concurrent-output also increases its upper bound.