### PR TITLE
add relation stuff ala === and /==

### DIFF
--- a/hedgehog-example/src/Test/Example/Basic.hs
+++ b/hedgehog-example/src/Test/Example/Basic.hs
@@ -70,8 +70,8 @@ prop_foo =
 
     guard (y `mod` 2 == (1 :: Int))
 
-    assert $
-      y < 87 && x <= 'r'
+    diff y (<) 87
+    diff x (<=) 'r'
 
 ------------------------------------------------------------------------
 -- Example 3
@@ -251,7 +251,7 @@ prop_record =
   property $ do
     x <- forAll genRecord
     y <- forAll genRecord
-    x === y
+    diff x (==) y
 
 prop_different_record :: Property
 prop_different_record =

--- a/hedgehog/src/Hedgehog.hs
+++ b/hedgehog/src/Hedgehog.hs
@@ -98,12 +98,9 @@ module Hedgehog (
   , success
   , failure
   , assert
+  , diff
   , (===)
   , (/==)
-  , (<==)
-  , (>==)
-  , (<<<)
-  , (>>>)
   , tripping
 
   , eval
@@ -154,8 +151,8 @@ import           Hedgehog.Internal.Distributive (Distributive(..))
 import           Hedgehog.Internal.Gen (Gen, GenT, MonadGen(..))
 import           Hedgehog.Internal.HTraversable (HTraversable(..))
 import           Hedgehog.Internal.Opaque (Opaque(..))
-import           Hedgehog.Internal.Property (annotate, annotateShow)
-import           Hedgehog.Internal.Property (assert, (===), (/==), (<==), (>==), (<<<), (>>>))
+import           Hedgehog.Internal.Property (assert, diff, annotate, annotateShow)
+import           Hedgehog.Internal.Property ((===), (/==))
 import           Hedgehog.Internal.Property (discard, failure, success)
 import           Hedgehog.Internal.Property (DiscardLimit, withDiscards)
 import           Hedgehog.Internal.Property (eval, evalM, evalIO)

--- a/hedgehog/src/Hedgehog.hs
+++ b/hedgehog/src/Hedgehog.hs
@@ -100,6 +100,10 @@ module Hedgehog (
   , assert
   , (===)
   , (/==)
+  , (<==)
+  , (>==)
+  , (<<<)
+  , (>>>)
   , tripping
 
   , eval
@@ -151,7 +155,7 @@ import           Hedgehog.Internal.Gen (Gen, GenT, MonadGen(..))
 import           Hedgehog.Internal.HTraversable (HTraversable(..))
 import           Hedgehog.Internal.Opaque (Opaque(..))
 import           Hedgehog.Internal.Property (annotate, annotateShow)
-import           Hedgehog.Internal.Property (assert, (===), (/==))
+import           Hedgehog.Internal.Property (assert, (===), (/==), (<==), (>==), (<<<), (>>>))
 import           Hedgehog.Internal.Property (discard, failure, success)
 import           Hedgehog.Internal.Property (DiscardLimit, withDiscards)
 import           Hedgehog.Internal.Property (eval, evalM, evalIO)

--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -56,6 +56,10 @@ module Hedgehog.Internal.Property (
   , assert
   , (===)
   , (/==)
+  , (<==)
+  , (>==)
+  , (<<<)
+  , (>>>)
 
   , eval
   , evalM
@@ -577,6 +581,50 @@ infix 4 /==
           "━━━ Both equal to ━━━"
         , showPretty x
         ]
+
+infix 4 <==
+
+-- | Fails the test if the right argument is less than the left.
+--
+(<==) :: (MonadTest m, Ord a, Show a, HasCallStack) => a -> a -> m ()
+(<==) x y = do
+  ok <- withFrozenCallStack $ eval (x <= y)
+  if ok then
+    success
+  else
+    withFrozenCallStack $ failDiff x y
+
+infix 4 >==
+
+-- | Fails the test if the right argument is greater than the left.
+(>==) :: (MonadTest m, Ord a, Show a, HasCallStack) => a -> a -> m ()
+(>==) x y = do
+  ok <- withFrozenCallStack $ eval (x >= y)
+  if ok then
+    success
+  else
+    withFrozenCallStack $ failDiff x y
+
+infix 4 <<<
+
+-- | Fails the test if the right argument is less than or equal to the left.
+(<<<) :: (MonadTest m, Ord a, Show a, HasCallStack) => a -> a -> m ()
+(<<<) x y = do
+  ok <- withFrozenCallStack $ eval (x < y)
+  if ok then
+    success
+  else
+    withFrozenCallStack $ failDiff x y
+
+infix 4 >>>
+
+(>>>) :: (MonadTest m, Ord a, Show a, HasCallStack) => a -> a -> m ()
+(>>>) x y = do
+  ok <- withFrozenCallStack $ eval (x > y)
+  if ok then
+    success
+  else
+    withFrozenCallStack $ failDiff x y
 
 -- | Fails the test if the value throws an exception when evaluated to weak
 --   head normal form (WHNF).

--- a/hedgehog/src/Hedgehog/Internal/Report.hs
+++ b/hedgehog/src/Hedgehog/Internal/Report.hs
@@ -496,8 +496,8 @@ ppLineDiff = \case
 ppDiff :: Diff -> [Doc Markup]
 ppDiff (Diff prefix removed infix_ added suffix diff) = [
     markup DiffPrefix (WL.text prefix) <>
-    markup DiffRemoved (WL.text removed) <+>
-    markup DiffInfix (WL.text infix_) <+>
+    markup DiffRemoved (WL.text removed) <>
+    markup DiffInfix (WL.text infix_) <>
     markup DiffAdded (WL.text added) <>
     markup DiffSuffix (WL.text suffix)
   ] ++ fmap ppLineDiff (toLineDiff diff)

--- a/hedgehog/src/Hedgehog/Internal/Tripping.hs
+++ b/hedgehog/src/Hedgehog/Internal/Tripping.hs
@@ -3,9 +3,9 @@ module Hedgehog.Internal.Tripping (
     tripping
   ) where
 
-import           Hedgehog.Internal.Property
-import           Hedgehog.Internal.Show
-import           Hedgehog.Internal.Source
+import           Hedgehog.Internal.Property (MonadTest, Diff(..), success, failWith)
+import           Hedgehog.Internal.Show (valueDiff, mkValue, showPretty)
+import           Hedgehog.Internal.Source (HasCallStack, withFrozenCallStack)
 
 
 -- | Test that a pair of encode / decode functions are compatible.
@@ -56,7 +56,8 @@ tripping x encode decode =
         Just diff ->
           withFrozenCallStack $
             failWith
-              (Just $ Diff "━━━ " "- Original" "/" "+ Roundtrip" " ━━━" diff) $
+              (Just $
+                Diff "━━━ " "- Original" ") (" "+ Roundtrip" " ━━━" diff) $
               unlines [
                   "━━━ Intermediate ━━━"
                 , showPretty i


### PR DESCRIPTION
This PR adds 4 functions, that have similar behaviour to === and /==, except they correspond to different relations.

(<==) ~> (<=)
(>==) ~> (>=)

(>>>) ~> (>)
(<<<) ~> (<)

As for naming, I tried to keep them to three characters while making sure their names didn't conflict with anything popular.

The reason I wanted this is that I was doing some numerical computations and wanted to test that the result of a computation was less than or equal to a particular value.
