### PR TITLE
Property: Add evalLeft and isLeft

### DIFF
--- a/hedgehog/src/Hedgehog.hs
+++ b/hedgehog/src/Hedgehog.hs
@@ -105,7 +105,9 @@ module Hedgehog (
   , evalM
   , evalIO
   , evalEither
+  , evalLeft
   , evalExceptT
+  , isLeft
 
   -- * State Machine Tests
   , Command(..)
@@ -151,7 +153,7 @@ import           Hedgehog.Internal.Property (assert, (===), (/==))
 import           Hedgehog.Internal.Property (discard, failure, success)
 import           Hedgehog.Internal.Property (DiscardLimit, withDiscards)
 import           Hedgehog.Internal.Property (eval, evalM, evalIO)
-import           Hedgehog.Internal.Property (evalEither, evalExceptT)
+import           Hedgehog.Internal.Property (evalEither, evalLeft, evalExceptT, isLeft)
 import           Hedgehog.Internal.Property (footnote, footnoteShow)
 import           Hedgehog.Internal.Property (forAll, forAllWith)
 import           Hedgehog.Internal.Property (MonadTest(..))


### PR DESCRIPTION
I am using `isLeft` now for the use case mentioned in the haddock text.

`evalLeft` I am less sure of. I can see it being useful for testing that correct errors are being generated. An example would be a generator that generates malformed binary serialisations and the expected error message.