### PR TITLE
Add note about enumBounded

### DIFF
--- a/hedgehog/src/Hedgehog/Internal/Gen.hs
+++ b/hedgehog/src/Hedgehog/Internal/Gen.hs
@@ -957,6 +957,8 @@ enum lo hi =
 -- enumBounded :: 'Gen' 'Bool'
 -- @
 --
+--   /This is implemented in terms of the 'Enum' class, and thus may be
+--    partial for integral types larger than 'Int', e.g. 'Word64'./
 enumBounded :: (MonadGen m, Enum a, Bounded a) => m a
 enumBounded =
   enum minBound maxBound


### PR DESCRIPTION
'enumBounded' is partial in some cases. Usually you actually want something like `Gen.linear minBound maxBound` or similar. The error message is pretty inscrutable when you mess it up (no source locations), so I think a cautionary message is worthwhile.

Bikeshed on wording welcome