### PR TITLE
Report Test.Hedgehog.Seed tests individually

### DIFF
--- a/hedgehog/test/Test/Hedgehog/Seed.hs
+++ b/hedgehog/test/Test/Hedgehog/Seed.hs
@@ -1,84 +1,78 @@
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE OverloadedStrings #-}
 module Test.Hedgehog.Seed (
     tests
   ) where
 
-import           Data.Foldable (for_)
-
 import           Hedgehog
 import qualified Hedgehog.Internal.Seed as Seed
-
-data Assert =
-  Assert {
-      expected :: !Seed
-    , actual   :: !Seed
-    } deriving (Show)
-
--- | Verify that SplitMix avoids pathological γ-values, as discussed by
---   Melissa E. O'Neill in the post with title Bugs in SplitMix(es), at
---   http://www.pcg-random.org/posts/bugs-in-splitmix.html
---
---   See also:
---   https://github.com/hedgehogqa/haskell-hedgehog/issues/191
---
-prop_avoid_pathological_gamma_values :: Property
-prop_avoid_pathological_gamma_values =
-  withTests 1 . property $ do
-    for_ asserts $ \a ->
-      expected a === actual a
-
-asserts :: [Assert]
-asserts = [
-    Assert
-      (Seed 15210016002011668638 12297829382473034411)
-      (Seed.from 0x61c8864680b583eb)
-  , Assert
-      (Seed 11409286845259996466 12297829382473034411)
-      (Seed.from 0xf8364607e9c949bd)
-  , Assert
-      (Seed 1931727433621677744 12297829382473034411)
-      (Seed.from 0x88e48f4fcc823718)
-  , Assert
-      (Seed 307741759840609752 12297829382473034411)
-      (Seed.from 0x7f83ab8da2e71dd1)
-  , Assert
-      (Seed 8606169619657412120 12297829382473034413)
-      (Seed.from 0x7957d809e827ff4c)
-  , Assert
-      (Seed 13651108307767328632 12297829382473034413)
-      (Seed.from 0xf8d059aee4c53639)
-  , Assert
-      (Seed 125750466559701114 12297829382473034413)
-      (Seed.from 0x9cd9f015db4e58b7)
-  , Assert
-      (Seed 6781260234005250507 12297829382473034413)
-      (Seed.from 0xf4077b0dbebc73c0)
-  , Assert
-      (Seed 15306535823716590088 12297829382473034405)
-      (Seed.from 0x305cb877109d0686)
-  , Assert
-      (Seed 7344074043290227165 12297829382473034405)
-      (Seed.from 0x359e58eeafebd527)
-  , Assert
-      (Seed 9920554987610416076 12297829382473034405)
-      (Seed.from 0xbeb721c511b0da6d)
-  , Assert
-      (Seed 3341781972484278810 12297829382473034405)
-      (Seed.from 0x86466fd0fcc363a6)
-  , Assert
-      (Seed 12360157267739240775 12297829382473034421)
-      (Seed.from 0xefee3e7b93db3075)
-  , Assert
-      (Seed 600595566262245170 12297829382473034421)
-      (Seed.from 0x79629ee76aa83059)
-  , Assert
-      (Seed 1471112649570176389 12297829382473034421)
-      (Seed.from 0x05d507d05e785673)
-  , Assert
-      (Seed 8100917074368564322 12297829382473034421)
-      (Seed.from 0x76442b62dddf926c)
-  ]
+import           Hedgehog.Internal.Property (PropertyName(..))
 
 tests :: IO Bool
 tests =
-  checkParallel $$(discover)
+  checkParallel $ Group "Test.Hedgehog.Seed" $
+    -- | Verify that SplitMix avoids pathological γ-values, as discussed by
+    --   Melissa E. O'Neill in the post with title Bugs in SplitMix(es), at
+    --   http://www.pcg-random.org/posts/bugs-in-splitmix.html
+    --
+    --   See also:
+    --   https://github.com/hedgehogqa/haskell-hedgehog/issues/191
+    --
+    do
+    (expected, actual) <-
+      [
+        ( Seed 15210016002011668638 12297829382473034411
+        , Seed.from 0x61c8864680b583eb
+        )
+      , ( Seed 11409286845259996466 12297829382473034411
+        , Seed.from 0xf8364607e9c949bd
+        )
+      , ( Seed 1931727433621677744 12297829382473034411
+        , Seed.from 0x88e48f4fcc823718
+        )
+      , ( Seed 307741759840609752 12297829382473034411
+        , Seed.from 0x7f83ab8da2e71dd1
+        )
+      , ( Seed 8606169619657412120 12297829382473034413
+        , Seed.from 0x7957d809e827ff4c
+        )
+      , ( Seed 13651108307767328632 12297829382473034413
+        , Seed.from 0xf8d059aee4c53639
+        )
+      , ( Seed 125750466559701114 12297829382473034413
+        , Seed.from 0x9cd9f015db4e58b7
+        )
+      , ( Seed 6781260234005250507 12297829382473034413
+        , Seed.from 0xf4077b0dbebc73c0
+        )
+      , ( Seed 15306535823716590088 12297829382473034405
+        , Seed.from 0x305cb877109d0686
+        )
+      , ( Seed 7344074043290227165 12297829382473034405
+        , Seed.from 0x359e58eeafebd527
+        )
+      , ( Seed 9920554987610416076 12297829382473034405
+        , Seed.from 0xbeb721c511b0da6d
+        )
+      , ( Seed 3341781972484278810 12297829382473034405
+        , Seed.from 0x86466fd0fcc363a6
+        )
+      , ( Seed 12360157267739240775 12297829382473034421
+        , Seed.from 0xefee3e7b93db3075
+        )
+      , ( Seed 600595566262245170 12297829382473034421
+        , Seed.from 0x79629ee76aa83059
+        )
+      , ( Seed 1471112649570176389 12297829382473034421
+        , Seed.from 0x05d507d05e785673
+        )
+      , ( Seed 8100917074368564322 12297829382473034421
+        , Seed.from 0x76442b62dddf926c
+        )
+      ]
+    return
+      ( PropertyName $ "prop_avoid_pathological_gamma_values → " ++ show actual ++ ","
+      , withTests 1 . property $ do
+          footnote $ "expected: " ++ show expected
+          footnote $ "actual: " ++ show actual
+          expected === actual
+      )


### PR DESCRIPTION
@thumphries, those deterministic tests added in #207, they've been reported as *1 test* which is incorrect:

```haskell
prop_avoid_pathological_gamma_values :: Property
prop_avoid_pathological_gamma_values =
  withTests 1 . property $ do
    for_ asserts $ \a ->
      expected a === actual a
```
    ━━━ Test.Hedgehog.Seed ━━━
      ✓ prop_avoid_pathological_gamma_values passed 1 test.
      ✓ 1 succeeded.

It turns out that [`Group`](http://hackage.haskell.org/package/hedgehog-0.6/docs/Hedgehog.html#t:Group) is all we need, since it's really a named collection of property tests:

```haskell
-- | A named collection of property tests.
--
data Group =
  Group {
      groupName :: !GroupName
    , groupProperties :: ![(PropertyName, Property)]
    }
```

So I did this, which is actually cool for fully deterministic tests:

```haskell
checkParallel $ Group "Test.Hedgehog.Seed" $
  -- | Verify that SplitMix avoids pathological γ-values, as discussed by
  --   Melissa E. O'Neill in the post with title Bugs in SplitMix(es), at
  --   http://www.pcg-random.org/posts/bugs-in-splitmix.html
  --
  --   See also:
  --   https://github.com/hedgehogqa/haskell-hedgehog/issues/191
  --
  do
  (expected, actual) <-
    [
      ( Seed 15210016002011668638 12297829382473034411
      , Seed.from 0x61c8864680b583eb
      )
    , ( Seed 11409286845259996466 12297829382473034411
      , Seed.from 0xf8364607e9c949bd
      )
    ...
    ]
  return
    ( "SplitMix avoids pathological γ-values,"
    , withTests 1 . property $ expected === actual
    )
```
    ━━━ Test.Hedgehog.Seed ━━━
      ✓ SplitMix avoids pathological γ-values, passed 1 test.
      ✓ SplitMix avoids pathological γ-values, passed 1 test.
      ✓ SplitMix avoids pathological γ-values, passed 1 test.
      ✓ SplitMix avoids pathological γ-values, passed 1 test.
      ✓ SplitMix avoids pathological γ-values, passed 1 test.
      ✓ SplitMix avoids pathological γ-values, passed 1 test.
      ✓ SplitMix avoids pathological γ-values, passed 1 test.
      ✓ SplitMix avoids pathological γ-values, passed 1 test.
      ✓ SplitMix avoids pathological γ-values, passed 1 test.
      ✓ SplitMix avoids pathological γ-values, passed 1 test.
      ✓ SplitMix avoids pathological γ-values, passed 1 test.
      ✓ SplitMix avoids pathological γ-values, passed 1 test.
      ✓ SplitMix avoids pathological γ-values, passed 1 test.
      ✓ SplitMix avoids pathological γ-values, passed 1 test.
      ✓ SplitMix avoids pathological γ-values, passed 1 test.
      ✓ SplitMix avoids pathological γ-values, passed 1 test.
      ✓ 16 succeeded.

/cc @jystic, @thumphries 