### PR TITLE
Set stdout/stderr encoding to UTF-8 on Windows

### DIFF
--- a/hedgehog/src/Hedgehog/Internal/Report.hs
+++ b/hedgehog/src/Hedgehog/Internal/Report.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_HADDOCK not-home #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveTraversable #-}
@@ -63,6 +64,9 @@ import           System.Console.ANSI (ColorIntensity(..), Color(..))
 import           System.Console.ANSI (ConsoleLayer(..), ConsoleIntensity(..))
 import           System.Console.ANSI (SGR(..), setSGRCode)
 import           System.Directory (makeRelativeToCurrentDirectory)
+#if mingw32_HOST_OS
+import           System.IO (hSetEncoding, stdout, stderr, utf8)
+#endif
 
 import           Text.PrettyPrint.Annotated.WL (Doc, (<+>))
 import qualified Text.PrettyPrint.Annotated.WL as WL
@@ -885,6 +889,11 @@ renderDoc mcolor doc = do
         DisableColor ->
           WL.display
 
+#if mingw32_HOST_OS
+  liftIO $ do
+    hSetEncoding stdout utf8
+    hSetEncoding stderr utf8
+#endif
   pure .
     display .
     WL.renderSmart 100 $

--- a/hedgehog/src/Hedgehog/Internal/Runner.hs
+++ b/hedgehog/src/Hedgehog/Internal/Runner.hs
@@ -1,5 +1,6 @@
 {-# OPTIONS_HADDOCK not-home #-}
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DoAndIfThenElse #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
@@ -45,6 +46,9 @@ import           Hedgehog.Range (Size)
 
 import           Language.Haskell.TH.Lift (deriveLift)
 
+#if mingw32_HOST_OS
+import           System.IO (hSetEncoding, stdout, stderr, utf8)
+#endif
 
 -- | Configuration for a property test run.
 --
@@ -265,6 +269,10 @@ checkGroup config (Group group props) =
     -- our tests will saturate all the capabilities they're given.
     updateNumCapabilities (n + 2)
 
+#if mingw32_HOST_OS
+    hSetEncoding stdout utf8
+    hSetEncoding stderr utf8
+#endif
     putStrLn $ "━━━ " ++ unGroupName group ++ " ━━━"
 
     verbosity <- resolveVerbosity (runnerVerbosity config)


### PR DESCRIPTION
There are two issues on Windows:

1. ```
    <stdout>: commitBuffer: invalid argument (invalid character)
    ```
2. ```
    ΓöüΓöüΓöü Q49343774 ΓöüΓöüΓöü
      Γ£ô prop_reverse passed 100 tests.
      Γ£ô 1 succeeded.
    True
    ```

---

- Issue `1` is annoying—it terminates the process and [breaks CIs](https://github.com/input-output-hk/cardano-sl/commit/315a264bf304fc62d7786091a44363badd29c1c3) [and stuff like that](https://github.com/hedgehogqa/haskell-hedgehog/issues/178)
- Issue `2` can either be addressed by [cooking some al dente](https://github.com/commercialhaskell/stack/blob/dc04605ea1a6648f8e1429a0a34886fcbf53b0cc/src/Stack/Build.hs#L296-L341) or by just typing `chcp 65001`
---

Resolves #110 by fixing issue `1`.