### PR TITLE
Update resourcet upper bound

### DIFF
--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -64,7 +64,7 @@ library
     , pretty-show                     >= 1.6        && < 1.8
     , primitive                       >= 0.6        && < 0.7
     , random                          >= 1.1        && < 1.2
-    , resourcet                       >= 1.1        && < 1.3
+    , resourcet                       >= 1.1        && < 1.2
     , semigroups                      >= 0.16       && < 0.19
     , stm                             >= 2.4        && < 2.5
     , template-haskell                >= 2.10       && < 2.14


### PR DESCRIPTION
resourcet starts using `MonadUnliftIO` instead of `MonadBaseControl IO`
with 1.2 so hedgehog can only be used with `resourcet < 1.2`.