### PR TITLE
Remove the dependency on the unix package

### DIFF
--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -75,10 +75,6 @@ library
     , transformers-base               >= 0.4        && < 0.5
     , wl-pprint-annotated             >= 0.0        && < 0.2
 
-  if !os(windows)
-    build-depends:
-      unix                            >= 2.6        && < 2.8
-
   ghc-options:
     -Wall
 


### PR DESCRIPTION
I could be missing something big here, but detectMark doesn't seem like it's doing much and it's the only thing using the unix dep.

getEffectiveUserName caused tests to fail on the scratch image I use in my CI setup. I could fix that by populating passwd, but it seemed cleaner to remove it here if it's not needed.