### PR TITLE
Update upper bounds for many dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -126,7 +126,7 @@ script:
 
   # build & run tests, build benchmarks
   - cabal new-build -w ${HC} ${TEST} ${BENCH} all
-  - if [ "x$TEST" = "x--enable-tests" ]; then cabal new-test -w ${HC} ${TEST} ${BENCH} all; fi
+  - if [ "x$TEST" = "x--enable-tests" ]; then travis_wait 30 cabal new-test -w ${HC} ${TEST} ${BENCH} all; fi
 
   # cabal check
   - (cd hedgehog-* && cabal check)

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 #
 #   runghc make_travis_yml_2.hs 'cabal.project'
 #
-# For more information, see https://github.com/hvr/multi-ghc-travis
+# For more information, see https://github.com/haskell-CI/haskell-ci
 #
 language: c
 sudo: false
@@ -28,6 +28,9 @@ before_cache:
 
 matrix:
   include:
+    - compiler: "ghc-8.6.1"
+    # env: TEST=--disable-tests BENCH=--disable-benchmarks
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.6.1], sources: [hvr-ghc]}}
     - compiler: "ghc-8.4.3"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.2,ghc-8.4.3], sources: [hvr-ghc]}}
@@ -81,7 +84,7 @@ install:
   - grep -Ev -- '^\s*--' ${HOME}/.cabal/config | grep -Ev '^\s*$'
   - "printf 'packages: \"hedgehog\" \"hedgehog-dieharder\" \"hedgehog-example\" \"hedgehog-quickcheck\"\\n' > cabal.project"
   - touch cabal.project.local
-  - "if ! $NOINSTALLEDCONSTRAINTS; then for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/^/constraints: /' | sed 's/-[^-]*$/ installed/' >> cabal.project.local; done; fi"
+  - "if ! $NOINSTALLEDCONSTRAINTS; then for pkg in $($HCPKG list --simple-output); do echo $pkg  | grep -vw -- hedgehog | grep -vw -- hedgehog-dieharder | grep -vw -- hedgehog-example | grep -vw -- hedgehog-quickcheck | sed 's/^/constraints: /' | sed 's/-[^-]*$/ installed/' >> cabal.project.local; done; fi"
   - cat cabal.project || true
   - cat cabal.project.local || true
   - if [ -f "hedgehog/configure.ac" ]; then
@@ -115,7 +118,7 @@ script:
   - find . -maxdepth 1 -name '*.tar.gz' -exec tar -xvf '{}' \;
   - "printf 'packages: hedgehog-*/*.cabal hedgehog-dieharder-*/*.cabal hedgehog-example-*/*.cabal hedgehog-quickcheck-*/*.cabal\\n' > cabal.project"
   - touch cabal.project.local
-  - "if ! $NOINSTALLEDCONSTRAINTS; then for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/^/constraints: /' | sed 's/-[^-]*$/ installed/' >> cabal.project.local; done; fi"
+  - "if ! $NOINSTALLEDCONSTRAINTS; then for pkg in $($HCPKG list --simple-output); do echo $pkg  | grep -vw -- hedgehog | grep -vw -- hedgehog-dieharder | grep -vw -- hedgehog-example | grep -vw -- hedgehog-quickcheck | sed 's/^/constraints: /' | sed 's/-[^-]*$/ installed/' >> cabal.project.local; done; fi"
   - cat cabal.project || true
   - cat cabal.project.local || true
   # this builds all libraries and executables (without tests/benchmarks)
@@ -123,7 +126,7 @@ script:
 
   # build & run tests, build benchmarks
   - cabal new-build -w ${HC} ${TEST} ${BENCH} all
-  - if [ "x$TEST" = "x--enable-tests" ]; then travis_wait 30 cabal new-test -w ${HC} ${TEST} ${BENCH} all; fi
+  - if [ "x$TEST" = "x--enable-tests" ]; then cabal new-test -w ${HC} ${TEST} ${BENCH} all; fi
 
   # cabal check
   - (cd hedgehog-* && cabal check)

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,34 +30,34 @@ matrix:
   include:
     - compiler: "ghc-8.6.1"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.6.1], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.6.1], sources: [hvr-ghc]}}
     - compiler: "ghc-8.4.3"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.2,ghc-8.4.3], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.4.3], sources: [hvr-ghc]}}
     - compiler: "ghc-8.4.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.2,ghc-8.4.2], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.4.2], sources: [hvr-ghc]}}
     - compiler: "ghc-8.4.1"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.2,ghc-8.4.1], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.4.1], sources: [hvr-ghc]}}
     - compiler: "ghc-8.2.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.2,ghc-8.2.2], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.2.2], sources: [hvr-ghc]}}
     - compiler: "ghc-8.2.1"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.2,ghc-8.2.1], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.2.1], sources: [hvr-ghc]}}
     - compiler: "ghc-8.0.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.2,ghc-8.0.2], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.0.2], sources: [hvr-ghc]}}
     - compiler: "ghc-8.0.1"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.2,ghc-8.0.1], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.0.1], sources: [hvr-ghc]}}
     - compiler: "ghc-7.10.3"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.2,ghc-7.10.3], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-7.10.3], sources: [hvr-ghc]}}
     - compiler: "ghc-7.10.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.2,ghc-7.10.2], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-7.10.2], sources: [hvr-ghc]}}
 
 before_install:
   - HC=${CC}

--- a/hedgehog-dieharder/hedgehog-dieharder.cabal
+++ b/hedgehog-dieharder/hedgehog-dieharder.cabal
@@ -34,6 +34,7 @@ tested-with:
   , GHC == 8.4.1
   , GHC == 8.4.2
   , GHC == 8.4.3
+  , GHC == 8.6.1
 
 executable dieharder-input
   main-is:

--- a/hedgehog-example/hedgehog-example.cabal
+++ b/hedgehog-example/hedgehog-example.cabal
@@ -57,9 +57,9 @@ library
     , mmorph                          >= 1.0        && < 1.2
     , mtl                             >= 2.1        && < 2.3
     , parsec                          >= 3.1        && < 3.2
-    , pretty-show                     >= 1.6        && < 1.8
+    , pretty-show                     >= 1.6        && < 1.9
     , process                         >= 1.2        && < 1.7
-    , QuickCheck                      >= 2.7        && < 2.12
+    , QuickCheck                      >= 2.7        && < 2.13
     , resourcet                       >= 1.1        && < 1.2
     , temporary-resourcet             >= 0.1        && < 0.2
     , text                            >= 1.1        && < 1.3

--- a/hedgehog-example/hedgehog-example.cabal
+++ b/hedgehog-example/hedgehog-example.cabal
@@ -32,6 +32,7 @@ tested-with:
   , GHC == 8.4.1
   , GHC == 8.4.2
   , GHC == 8.4.3
+  , GHC == 8.6.1
 
 library
   hs-source-dirs:

--- a/hedgehog-quickcheck/hedgehog-quickcheck.cabal
+++ b/hedgehog-quickcheck/hedgehog-quickcheck.cabal
@@ -42,6 +42,7 @@ tested-with:
   , GHC == 8.4.1
   , GHC == 8.4.2
   , GHC == 8.4.3
+  , GHC == 8.6.1
 extra-source-files:
   README.md
   CHANGELOG.md

--- a/hedgehog-quickcheck/hedgehog-quickcheck.cabal
+++ b/hedgehog-quickcheck/hedgehog-quickcheck.cabal
@@ -54,7 +54,7 @@ library
   build-depends:
       base                            >= 3          && < 5
     , hedgehog                        >= 0.5        && < 0.7
-    , QuickCheck                      >= 2.7        && < 2.12
+    , QuickCheck                      >= 2.7        && < 2.13
     , transformers                    >= 0.4        && < 0.6
 
   ghc-options:

--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -61,13 +61,13 @@ library
     , mmorph                          >= 1.0        && < 1.2
     , monad-control                   >= 1.0        && < 1.1
     , mtl                             >= 2.1        && < 2.3
-    , pretty-show                     >= 1.6        && < 1.8
+    , pretty-show                     >= 1.6        && < 1.9
     , primitive                       >= 0.6        && < 0.7
     , random                          >= 1.1        && < 1.2
     , resourcet                       >= 1.1        && < 1.3
     , semigroups                      >= 0.16       && < 0.19
-    , stm                             >= 2.4        && < 2.5
-    , template-haskell                >= 2.10       && < 2.14
+    , stm                             >= 2.4        && < 2.6
+    , template-haskell                >= 2.10       && < 2.15
     , text                            >= 1.1        && < 1.3
     , th-lift                         >= 0.7        && < 0.8
     , time                            >= 1.4        && < 1.10
@@ -133,7 +133,7 @@ test-suite test
       hedgehog
     , base                            >= 3          && < 5
     , containers                      >= 0.4        && < 0.7
-    , pretty-show                     >= 1.6        && < 1.8
+    , pretty-show                     >= 1.6        && < 1.9
     , semigroups                      >= 0.16       && < 0.19
     , text                            >= 1.1        && < 1.3
     , transformers                    >= 0.3        && < 0.6

--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -39,6 +39,7 @@ tested-with:
   , GHC == 8.4.1
   , GHC == 8.4.2
   , GHC == 8.4.3
+  , GHC == 8.6.1
 extra-source-files:
   README.md
   CHANGELOG.md


### PR DESCRIPTION
Leave resourcet in hedgehog-example for now, since
it does not compile with newer resourcet

With these bounds in place, we should be able to build on GHC 8.6.1 once lifted-async has updated their base upper bound. When that happens I'll add 8.6.1 to the travis build.