### PR TITLE
Expose discoverPrefix to find prefixed properties

### DIFF
--- a/hedgehog/src/Hedgehog.hs
+++ b/hedgehog/src/Hedgehog.hs
@@ -62,6 +62,7 @@ module Hedgehog (
   , recheck
 
   , discover
+  , discoverPrefix
   , checkParallel
   , checkSequential
 
@@ -168,5 +169,5 @@ import           Hedgehog.Internal.State (Command(..), Callback(..))
 import           Hedgehog.Internal.State (Action, Sequential(..), Parallel(..))
 import           Hedgehog.Internal.State (executeSequential, executeParallel)
 import           Hedgehog.Internal.State (Var(..), Symbolic, Concrete(..), concrete, opaque)
-import           Hedgehog.Internal.TH (discover)
+import           Hedgehog.Internal.TH (discover, discoverPrefix)
 import           Hedgehog.Internal.Tripping (tripping)

--- a/hedgehog/src/Hedgehog/Internal/Discovery.hs
+++ b/hedgehog/src/Hedgehog/Internal/Discovery.hs
@@ -33,9 +33,9 @@ newtype PropertySource =
       propertySource :: Pos String
     } deriving (Eq, Ord, Show)
 
-readProperties :: MonadIO m => FilePath -> m (Map PropertyName PropertySource)
-readProperties path =
-  findProperties path <$> liftIO (readFile path)
+readProperties :: MonadIO m => String -> FilePath -> m (Map PropertyName PropertySource)
+readProperties prefix path =
+  findProperties prefix path <$> liftIO (readFile path)
 
 readDeclaration :: MonadIO m => FilePath -> LineNo -> m (Maybe (String, Pos String))
 readDeclaration path line = do
@@ -59,11 +59,11 @@ takeHead = \case
   x : _ ->
     Just x
 
-findProperties :: FilePath -> String -> Map PropertyName PropertySource
-findProperties path =
+findProperties :: String -> FilePath -> String -> Map PropertyName PropertySource
+findProperties prefix path =
   Map.map PropertySource .
   Map.mapKeysMonotonic PropertyName .
-  Map.filterWithKey (\k _ -> isProperty k) .
+  Map.filterWithKey (\k _ -> List.isPrefixOf prefix k) .
   findDeclarations path
 
 findDeclarations :: FilePath -> String -> Map String (Pos String)
@@ -71,10 +71,6 @@ findDeclarations path =
   declarations .
   classified .
   positioned path
-
-isProperty :: String -> Bool
-isProperty =
-  List.isPrefixOf "prop_"
 
 ------------------------------------------------------------------------
 -- Declaration Identification

--- a/hedgehog/src/Hedgehog/Internal/TH.hs
+++ b/hedgehog/src/Hedgehog/Internal/TH.hs
@@ -4,6 +4,7 @@
 module Hedgehog.Internal.TH (
     TExpQ
   , discover
+  , discoverPrefix
   ) where
 
 import qualified Data.List as List
@@ -24,9 +25,12 @@ type TExpQ a =
 --   Functions starting with `prop_` are assumed to be properties.
 --
 discover :: TExpQ Group
-discover = do
+discover = discoverPrefix "prop_"
+
+discoverPrefix :: String -> TExpQ Group
+discoverPrefix prefix = do
   file <- getCurrentFile
-  properties <- Map.toList <$> runIO (readProperties file)
+  properties <- Map.toList <$> runIO (readProperties prefix file)
 
   let
     startLine =


### PR DESCRIPTION
We are using this change to have specific sets of properties, for example golden tests, with their own prefix.