### PR TITLE
Add MonadFail instances where appropriate

### DIFF
--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -58,6 +58,7 @@ library
     , containers                      >= 0.4        && < 0.7
     , directory                       >= 1.2        && < 1.4
     , exceptions                      >= 0.7        && < 0.11
+    , fail                            == 4.9.*
     , lifted-async                    >= 0.7        && < 0.11
     , mmorph                          >= 1.0        && < 1.2
     , monad-control                   >= 1.0        && < 1.1

--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -58,7 +58,7 @@ library
     , containers                      >= 0.4        && < 0.7
     , directory                       >= 1.2        && < 1.4
     , exceptions                      >= 0.7        && < 0.11
-    , fail                            == 4.9.*
+    , fail                            >= 4.9        && < 5
     , lifted-async                    >= 0.7        && < 0.11
     , mmorph                          >= 1.0        && < 1.2
     , monad-control                   >= 1.0        && < 1.1

--- a/hedgehog/src/Hedgehog/Internal/Gen.hs
+++ b/hedgehog/src/Hedgehog/Internal/Gen.hs
@@ -158,6 +158,8 @@ import           Control.Monad (MonadPlus(..), filterM, replicateM, ap, join)
 import           Control.Monad.Base (MonadBase(..))
 import           Control.Monad.Catch (MonadThrow(..), MonadCatch(..))
 import           Control.Monad.Error.Class (MonadError(..))
+import           Control.Monad.Fail (MonadFail (..))
+import qualified Control.Monad.Fail as Fail
 import           Control.Monad.IO.Class (MonadIO(..))
 import           Control.Monad.Morph (MFunctor(..), MMonad(..), generalize)
 import           Control.Monad.Primitive (PrimMonad(..))
@@ -552,6 +554,13 @@ instance Monad m => Monad (GenT m) where
         (sk, sm) ->
           runGenT size sk . k =<<
           runGenT size sm m
+
+  fail =
+    Fail.fail
+
+instance Monad m => MonadFail (GenT m) where
+  fail =
+    error
 
 instance Monad m => Alternative (GenT m) where
   empty =

--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -84,6 +84,8 @@ import           Control.Monad.Base (MonadBase(..))
 import           Control.Monad.Catch (MonadThrow(..), MonadCatch(..))
 import           Control.Monad.Catch (SomeException(..), displayException)
 import           Control.Monad.Error.Class (MonadError(..))
+import           Control.Monad.Fail (MonadFail (..))
+import qualified Control.Monad.Fail as Fail
 import           Control.Monad.IO.Class (MonadIO(..))
 import           Control.Monad.Morph (MFunctor(..))
 import           Control.Monad.Primitive (PrimMonad(..))
@@ -317,6 +319,10 @@ instance Monad m => Monad (TestT m) where
       unTest m >>=
       unTest . k
 
+  fail =
+    Fail.fail
+
+instance Monad m => MonadFail (TestT m) where
   fail err =
     TestT . ExceptT . pure . Left $ Failure Nothing err Nothing
 


### PR DESCRIPTION
Some folks might use generators in do notation with a partial pattern match, this won't work with GHC 8.6 without a MonadFail instance.

Although it's probably not the best practice, I would imagine that discarding the non-matching sample is better than throwing an exception.

~~Other that that I just turned on a few warnings and fixed them.~~
