### PR TITLE
Fix minor performance issue with color handling

### DIFF
--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -78,7 +78,6 @@ library
 
   ghc-options:
     -Wall
-    -Werror
 
   hs-source-dirs:
     src

--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -78,6 +78,7 @@ library
 
   ghc-options:
     -Wall
+    -Werror
 
   hs-source-dirs:
     src

--- a/hedgehog/src/Hedgehog/Internal/Config.hs
+++ b/hedgehog/src/Hedgehog/Internal/Config.hs
@@ -6,13 +6,8 @@
 {-# LANGUAGE TemplateHaskell #-}
 module Hedgehog.Internal.Config (
     UseColor(..)
-  , resolveColor
-
   , Verbosity(..)
-  , resolveVerbosity
-
   , WorkerCount(..)
-  , resolveWorkers
 
   , detectMark
   , detectColor
@@ -133,27 +128,6 @@ detectWorkers = do
         WorkerCount <$> Conc.getNumProcessors
       Just env ->
         pure $ WorkerCount env
-
-resolveColor :: MonadIO m => Maybe UseColor -> m UseColor
-resolveColor = \case
-  Nothing ->
-    detectColor
-  Just x ->
-    pure x
-
-resolveVerbosity :: MonadIO m => Maybe Verbosity -> m Verbosity
-resolveVerbosity = \case
-  Nothing ->
-    detectVerbosity
-  Just x ->
-    pure x
-
-resolveWorkers :: MonadIO m => Maybe WorkerCount -> m WorkerCount
-resolveWorkers = \case
-  Nothing ->
-    detectWorkers
-  Just x ->
-    pure x
 
 ------------------------------------------------------------------------
 -- FIXME Replace with DeriveLift when we drop 7.10 support.

--- a/hedgehog/src/Hedgehog/Internal/Report.hs
+++ b/hedgehog/src/Hedgehog/Internal/Report.hs
@@ -784,7 +784,7 @@ ppSummary summary =
             Nothing
         ]
 
-renderDoc :: MonadIO m => Maybe UseColor -> Doc Markup -> m String
+renderDoc :: MonadIO m => UseColor -> Doc Markup -> m String
 renderDoc mcolor doc = do
   let
     dull =
@@ -879,11 +879,9 @@ renderDoc mcolor doc = do
     end _ =
       setSGRCode [Reset]
 
-  color <- resolveColor mcolor
-
   let
     display =
-      case color of
+      case mcolor of
         EnableColor ->
           WL.displayDecorated start end id
         DisableColor ->
@@ -899,14 +897,14 @@ renderDoc mcolor doc = do
     WL.renderSmart 100 $
     WL.indent 2 doc
 
-renderProgress :: MonadIO m => Maybe UseColor -> Maybe PropertyName -> Report Progress -> m String
+renderProgress :: MonadIO m => UseColor -> Maybe PropertyName -> Report Progress -> m String
 renderProgress mcolor name x =
   renderDoc mcolor =<< ppProgress name x
 
-renderResult :: MonadIO m => Maybe UseColor -> Maybe PropertyName -> Report Result -> m String
+renderResult :: MonadIO m => UseColor -> Maybe PropertyName -> Report Result -> m String
 renderResult mcolor name x =
   renderDoc mcolor =<< ppResult name x
 
-renderSummary :: MonadIO m => Maybe UseColor -> Summary -> m String
+renderSummary :: MonadIO m => UseColor -> Summary -> m String
 renderSummary mcolor x =
   renderDoc mcolor =<< ppSummary x

--- a/hedgehog/src/Hedgehog/Internal/Runner.hs
+++ b/hedgehog/src/Hedgehog/Internal/Runner.hs
@@ -240,7 +240,9 @@ recheck size seed prop0 = do
     checkRegion region mcolor Nothing size seed prop
   pure ()
 
-data Parallelism = UseParallelism | NoParallelism
+data Parallelism =
+    UseParallelism
+  | NoParallelism
 
 -- | Check a group of properties using the specified runner config.
 --

--- a/hedgehog/src/Hedgehog/Internal/Runner.hs
+++ b/hedgehog/src/Hedgehog/Internal/Runner.hs
@@ -244,15 +244,17 @@ checkNamed region mcolor name prop = do
 
 -- | Check a property.
 --
-check :: MonadIO m => UseColor -> Property -> m Bool
-check mcolor prop =
+check :: MonadIO m => Property -> m Bool
+check prop = do
+  mcolor <- detectColor
   liftIO . displayRegion $ \region ->
     (== OK) . reportStatus <$> checkNamed region mcolor Nothing prop
 
 -- | Check a property using a specific size and seed.
 --
-recheck :: MonadIO m => UseColor -> Size -> Seed -> Property -> m ()
-recheck mcolor size seed prop0 = do
+recheck :: MonadIO m => Size -> Seed -> Property -> m ()
+recheck size seed prop0 = do
+  mcolor <- detectColor
   let prop = withTests 1 prop0
   _ <- liftIO . displayRegion $ \region ->
     checkRegion region mcolor Nothing size seed prop

--- a/hedgehog/src/Hedgehog/Internal/Runner.hs
+++ b/hedgehog/src/Hedgehog/Internal/Runner.hs
@@ -240,12 +240,16 @@ recheck size seed prop0 = do
     checkRegion region mcolor Nothing size seed prop
   pure ()
 
+data Parallelism = UseParallelism | NoParallelism
+
 -- | Check a group of properties using the specified runner config.
 --
-checkGroup :: MonadIO m => Bool -> Group -> m Bool
-checkGroup useParallelism (Group group props) =
+checkGroup :: MonadIO m => Parallelism -> Group -> m Bool
+checkGroup parallelism (Group group props) =
   liftIO $ do
-    n <- if useParallelism then detectWorkers else pure 1
+    n <- case parallelism of
+        UseParallelism -> detectWorkers
+        NoParallelism -> pure 1
 
     -- ensure few spare capabilities for concurrent-output, it's likely that
     -- our tests will saturate all the capabilities they're given.
@@ -340,7 +344,7 @@ checkGroupWith n verbosity mcolor props =
 --
 --
 checkSequential :: MonadIO m => Group -> m Bool
-checkSequential = checkGroup False
+checkSequential = checkGroup NoParallelism
 
 
 -- | Check a group of properties in parallel.
@@ -366,4 +370,4 @@ checkSequential = checkGroup False
 -- >     ]
 --
 checkParallel :: MonadIO m => Group -> m Bool
-checkParallel = checkGroup True
+checkParallel = checkGroup UseParallelism

--- a/hedgehog/src/Hedgehog/Internal/Runner.hs
+++ b/hedgehog/src/Hedgehog/Internal/Runner.hs
@@ -12,7 +12,6 @@ module Hedgehog.Internal.Runner (
   , recheck
 
   -- * Running Groups of Properties
-  , RunnerConfig(..)
   , checkParallel
   , checkSequential
   , checkGroup
@@ -44,28 +43,9 @@ import qualified Hedgehog.Internal.Seed as Seed
 import           Hedgehog.Internal.Tree (Tree(..), Node(..))
 import           Hedgehog.Range (Size)
 
-import           Language.Haskell.TH.Lift (deriveLift)
-
 #if mingw32_HOST_OS
 import           System.IO (hSetEncoding, stdout, stderr, utf8)
 #endif
-
--- | Configuration for a property test run.
---
-data RunnerConfig =
-  RunnerConfig {
-      -- | The number of property tests to run concurrently. 'Nothing' means
-      --   use one worker per processor.
-      runnerWorkers :: !WorkerCount
-
-      -- | Whether to use colored output or not. 'Nothing' means detect from
-      --   the environment.
-    , runnerColor :: !UseColor
-
-      -- | How verbose to be in the runner output. 'Nothing' means detect from
-      --   the environment.
-    , runnerVerbosity :: !Verbosity
-    } deriving (Eq, Ord, Show)
 
 findM :: Monad m => [a] -> b -> (a -> m (Maybe b)) -> m b
 findM xs0 def p =
@@ -387,8 +367,3 @@ checkSequential = checkGroup False
 --
 checkParallel :: MonadIO m => Group -> m Bool
 checkParallel = checkGroup True
-
-------------------------------------------------------------------------
--- FIXME Replace with DeriveLift when we drop 7.10 support.
-
-$(deriveLift ''RunnerConfig)


### PR DESCRIPTION
Turns out `hSupportsANSI` is not the most efficient call:

```
$ cat spec-before.prof | head -20
	Tue Dec 11 20:42 2018 Time and Allocation Profiling Report  (Final)

	   spec +RTS -p -s -t -RTS

	total time  =        2.03 secs   (2026 ticks @ 1000 us, 1 processor)
	total alloc = 3,087,822,320 bytes  (excludes profiling overheads)

COST CENTRE             MODULE                   SRC                                              %time %alloc

>>=                     Hedgehog.Internal.Tree   src/Hedgehog/Internal/Tree.hs:(136,3)-(141,29)    11.4   11.5
hSupportsANSI.isNotDumb System.Console.ANSI.Unix src/System/Console/ANSI/Unix.hs:74:3-65            8.3   20.6
<*>                     Hedgehog.Internal.Gen    src/Hedgehog/Internal/Gen.hs:(542,3)-(543,6)       7.1    7.1
split                   Hedgehog.Internal.Seed   src/Hedgehog/Internal/Seed.hs:(135,1)-(140,39)     4.3    6.0
randomIvalInteger       System.Random            System/Random.hs:(468,1)-(489,76)                  4.0    3.2
runGenT                 Hedgehog.Internal.Gen    src/Hedgehog/Internal/Gen.hs:(233,1)-(234,13)      4.0    0.2
next                    Hedgehog.Internal.Seed   src/Hedgehog/Internal/Seed.hs:(126,1)-(130,17)     3.3    7.0
list.\                  Hedgehog.Internal.Gen    src/Hedgehog/Internal/Gen.hs:(1302,5)-(1306,31)    3.3    2.6
fmap                    Hedgehog.Internal.Tree   src/Hedgehog/Internal/Tree.hs:(107,3)-(108,34)     2.4    2.9
expand                  Hedgehog.Internal.Tree   src/Hedgehog/Internal/Tree.hs:(85,1)-(89,44)       2.2    2.2
>>=.\                   Hedgehog.Internal.Gen    src/Hedgehog/Internal/Gen.hs:(551,7)-(554,27)      2.0    4.0
```

This is somewhat of a problem because as it stands, hedgehog aggressively checks if the same terminal supports color every property run. This PR makes it check ANSI support once before running and never after, resulting in a 10ish% CPU saving on a CPU-intensive (if quite short) test:

```
$ cat spec-after.prof | head -20
	Tue Dec 11 21:07 2018 Time and Allocation Profiling Report  (Final)

	   spec +RTS -p -s -t -RTS

	total time  =        2.03 secs   (2030 ticks @ 1000 us, 1 processor)
	total alloc = 2,275,820,544 bytes  (excludes profiling overheads)

COST CENTRE            MODULE                     SRC                                                 %time %alloc

>>=                    Hedgehog.Internal.Tree     src/Hedgehog/Internal/Tree.hs:(136,3)-(141,29)       11.2   14.5
<*>                    Hedgehog.Internal.Gen      src/Hedgehog/Internal/Gen.hs:(542,3)-(543,6)          7.8    9.0
split                  Hedgehog.Internal.Seed     src/Hedgehog/Internal/Seed.hs:(135,1)-(140,39)        5.4    7.6
randomIvalInteger      System.Random              System/Random.hs:(468,1)-(489,76)                     4.3    4.1
runGenT                Hedgehog.Internal.Gen      src/Hedgehog/Internal/Gen.hs:(233,1)-(234,13)         3.7    0.3
next                   Hedgehog.Internal.Seed     src/Hedgehog/Internal/Seed.hs:(126,1)-(130,17)        3.7    8.9
list.\                 Hedgehog.Internal.Gen      src/Hedgehog/Internal/Gen.hs:(1302,5)-(1306,31)       3.3    3.2
>>=.\                  Hedgehog.Internal.Gen      src/Hedgehog/Internal/Gen.hs:(551,7)-(554,27)         3.0    5.1
expand                 Hedgehog.Internal.Tree     src/Hedgehog/Internal/Tree.hs:(85,1)-(89,44)          2.9    2.8
fmap                   Hedgehog.Internal.Tree     src/Hedgehog/Internal/Tree.hs:(107,3)-(108,34)        2.5    3.7
integral_.\            Hedgehog.Internal.Gen      src/Hedgehog/Internal/Gen.hs:(804,5)-(809,57)         2.4    2.3
```