### PR TITLE
Bump ansi-terminal upper bound

### DIFF
--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -52,7 +52,7 @@ source-repository head
 library
   build-depends:
       base                            >= 3          && < 5
-    , ansi-terminal                   >= 0.6        && < 0.9
+    , ansi-terminal                   >= 0.6        && < 0.10
     , async                           >= 2.0        && < 2.3
     , bytestring                      >= 0.10       && < 0.11
     , concurrent-output               >= 1.7        && < 1.11


### PR DESCRIPTION
I've already made the metadata revision corresponding to this pull request, so there's no need for a new release.