### PR TITLE
hedgehog-example: relax resourcet to < 1.3

### DIFF
--- a/hedgehog-example/hedgehog-example.cabal
+++ b/hedgehog-example/hedgehog-example.cabal
@@ -62,7 +62,7 @@ library
     , pretty-show                     >= 1.6        && < 1.10
     , process                         >= 1.2        && < 1.7
     , QuickCheck                      >= 2.7        && < 2.13
-    , resourcet                       >= 1.1        && < 1.2
+    , resourcet                       >= 1.1        && < 1.3
     , temporary-resourcet             >= 0.1        && < 0.2
     , text                            >= 1.1        && < 1.3
     , transformers                    >= 0.4        && < 0.6

--- a/hedgehog-example/src/Test/Example/Resource.hs
+++ b/hedgehog-example/src/Test/Example/Resource.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell #-}
+
 module Test.Example.Resource where
 
 import           Control.Monad.IO.Class (MonadIO(..))
+import           Control.Monad.Morph (hoist)
 import           Control.Monad.Trans.Except (ExceptT, throwE)
 import           Control.Monad.Trans.Resource (runResourceT)
 
@@ -15,8 +16,8 @@ import           System.FilePath ((</>))
 import qualified System.IO.Temp as Temp
 import           System.Process
 
-data ProcessFailed =
-  ProcessFailed !Int
+newtype ProcessFailed =
+  ProcessFailed Int
   deriving (Show)
 
 unixSort :: MonadIO m => FilePath -> FilePath -> ExceptT ProcessFailed m ()
@@ -43,7 +44,7 @@ prop_unix_sort =
       Gen.list (Range.linear 0 100) $
       Gen.string (Range.constant 1 5) Gen.alpha
 
-    test . runResourceT $ do
+    test . hoist runResourceT $ do
       (_, dir) <- Temp.createTempDirectory Nothing "prop_dir"
 
       let input = dir </> "input"


### PR DESCRIPTION
Relax bound, and use `hoist` to work with `MonadUnliftIO`.

See also: discussion about resourcet in #252 .