### PR TITLE
Bump QuickCheck upper bound

### DIFF
--- a/hedgehog-quickcheck/hedgehog-quickcheck.cabal
+++ b/hedgehog-quickcheck/hedgehog-quickcheck.cabal
@@ -56,7 +56,7 @@ library
   build-depends:
       base                            >= 3          && < 5
     , hedgehog                        >= 0.5        && < 0.7
-    , QuickCheck                      >= 2.7        && < 2.13
+    , QuickCheck                      >= 2.7        && < 2.14
     , transformers                    >= 0.4        && < 0.6
 
   ghc-options:


### PR DESCRIPTION
I suggest also making this change as a hackage metadata revision to the most recent release of hedgehog-quickcheck (I'm happy to do so if you'd like)