### PR TITLE
Add 'MonadFail' instance for 'PropertyT'

### DIFF
--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -624,6 +624,10 @@ instance MonadTrans PropertyT where
   lift =
     PropertyT . lift . lift
 
+instance Monad m => MonadFail (PropertyT m) where
+  fail err =
+    PropertyT (Fail.fail err)
+
 instance MFunctor PropertyT where
   hoist f =
     PropertyT . hoist (hoist f) . unPropertyT


### PR DESCRIPTION
Add `MonadFail` instance for `PropertyT` so users can write the following tests

    property $ do
      Just val <- lookupUnderTest
      assertSomeProperties val

The above test will produce a test failure when `lookupUnderTest` returns `Nothing`.

We build on the `MonadFail` instances for `TestT` provided by #233.