### PR TITLE
Make 'PropertyT' an instance of 'MonadResource'

### DIFF
--- a/hedgehog-example/src/Test/Example/Resource.hs
+++ b/hedgehog-example/src/Test/Example/Resource.hs
@@ -39,7 +39,7 @@ unixSort input output = do
 
 prop_unix_sort :: Property
 prop_unix_sort =
-  property $ hoist runResourceT $ do
+  property . hoist runResourceT $ do
     values0 <- forAll $
       Gen.list (Range.linear 0 100) $
       Gen.string (Range.constant 1 5) Gen.alpha

--- a/hedgehog-example/src/Test/Example/Resource.hs
+++ b/hedgehog-example/src/Test/Example/Resource.hs
@@ -39,22 +39,21 @@ unixSort input output = do
 
 prop_unix_sort :: Property
 prop_unix_sort =
-  property $ do
+  property $ hoist runResourceT $ do
     values0 <- forAll $
       Gen.list (Range.linear 0 100) $
       Gen.string (Range.constant 1 5) Gen.alpha
 
-    test . hoist runResourceT $ do
-      (_, dir) <- Temp.createTempDirectory Nothing "prop_dir"
+    (_, dir) <- Temp.createTempDirectory Nothing "prop_dir"
 
-      let input = dir </> "input"
-          output = dir </> "output"
+    let input = dir </> "input"
+        output = dir </> "output"
 
-      liftIO $ writeFile input (unlines values0)
-      evalExceptT $ unixSort input output
-      values <- liftIO . fmap lines $ readFile output
+    liftIO $ writeFile input (unlines values0)
+    evalExceptT $ unixSort input output
+    values <- liftIO . fmap lines $ readFile output
 
-      values0 === values
+    values0 === values
 
 tests :: IO Bool
 tests =

--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -150,6 +150,7 @@ newtype PropertyT m a =
     , MonadThrow
     , MonadCatch
     , MonadReader r
+    , MonadResource
     , MonadState s
     , MonadError e
     )

--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -150,10 +150,12 @@ newtype PropertyT m a =
     , MonadThrow
     , MonadCatch
     , MonadReader r
-    , MonadResource
     , MonadState s
     , MonadError e
     )
+
+-- NOTE: Move this to the deriving list above when we drop 7.10
+deriving instance MonadResource m => MonadResource (PropertyT m)
 
 -- | A test monad allows the assertion of expectations.
 --


### PR DESCRIPTION
Make `PropertyT` an instance of `MonadResource` simplifies writing tests that use the functions with a `MonadResource` constraint. See the changed example for instance.