### PR TITLE
Rename Hedgehog.runTests -> Hedgehog.Main.defaultMain

### DIFF
--- a/hedgehog/src/Hedgehog.hs
+++ b/hedgehog/src/Hedgehog.hs
@@ -142,9 +142,6 @@ module Hedgehog (
 
   , Show1
   , showsPrec1
-
-  -- * Test runner
-  , runTests
   ) where
 
 import           Data.Functor.Classes (Eq1, eq1, Ord1, compare1, Show1, showsPrec1)
@@ -171,7 +168,6 @@ import           Hedgehog.Internal.Property (Test, TestT, property, test)
 import           Hedgehog.Internal.Property (TestLimit, withTests)
 import           Hedgehog.Internal.Range (Range, Size(..))
 import           Hedgehog.Internal.Runner (check, recheck, checkSequential, checkParallel)
-import           Hedgehog.Internal.Runner (runTests)
 
 import           Hedgehog.Internal.Seed (Seed(..))
 import           Hedgehog.Internal.State (Command(..), Callback(..))

--- a/hedgehog/src/Hedgehog/Internal/Runner.hs
+++ b/hedgehog/src/Hedgehog/Internal/Runner.hs
@@ -17,9 +17,6 @@ module Hedgehog.Internal.Runner (
   , checkSequential
   , checkGroup
 
-  -- * Top level testsuite runner
-  , runTests
-
   -- * Internal
   , checkReport
   , checkRegion
@@ -435,16 +432,6 @@ checkParallel =
       , runnerVerbosity =
           Nothing
       }
-
--- | Like `runTests` but exit with `exitFailure` if one or more of the tests
--- fail.
-runTests :: [IO Bool] -> IO ()
-runTests tests = do
-  hSetBuffering stdout LineBuffering
-  hSetBuffering stderr LineBuffering
-  result <- and <$> sequence tests
-  unless result
-    exitFailure
 
 ------------------------------------------------------------------------
 -- FIXME Replace with DeriveLift when we drop 7.10 support.

--- a/hedgehog/src/Hedgehog/Main.hs
+++ b/hedgehog/src/Hedgehog/Main.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE CPP #-}
+module Hedgehog.Main (
+  -- * Running tests
+    defaultMain
+  ) where
+
+import           Control.Monad (unless)
+
+import           System.Exit (exitFailure)
+
+#if mingw32_HOST_OS
+import           System.IO (BufferMode (LineBuffering), hSetBuffering, hSetEncoding, stdout, stderr, utf8)
+#else
+import           System.IO (BufferMode (LineBuffering), hSetBuffering, stderr, stdout)
+#endif
+
+-- | An entry point that can be used as a main function.
+--
+defaultMain :: [IO Bool] -> IO ()
+defaultMain tests = do
+  hSetBuffering stdout LineBuffering
+  hSetBuffering stderr LineBuffering
+  result <- and <$> sequence tests
+  unless result
+    exitFailure

--- a/hedgehog/test/test.hs
+++ b/hedgehog/test/test.hs
@@ -1,4 +1,4 @@
-import           Hedgehog (runTests)
+import           Hedgehog.Main (defaultMain)
 
 import qualified Test.Hedgehog.Seed
 import qualified Test.Hedgehog.Text
@@ -6,7 +6,7 @@ import qualified Test.Hedgehog.Text
 
 main :: IO ()
 main =
-  runTests [
+  defaultMain [
       Test.Hedgehog.Text.tests
     , Test.Hedgehog.Seed.tests
     ]


### PR DESCRIPTION
`defaultMain` seems to be the convention in many Haskell packages which produce a command line program, so I think it will be less surprising / something people look for:

- [Cabal](http://hackage.haskell.org/package/Cabal-2.4.1.0/docs/Distribution-Simple.html#v:defaultMain)
- [Yesod](http://hackage.haskell.org/package/yesod-1.6.0/docs/Yesod-Default-Main.html)
- [Criterion](http://hackage.haskell.org/package/criterion-1.5.4.0/docs/Criterion-Main.html)
- [Tasty](http://hackage.haskell.org/package/tasty-1.2.1/docs/Test-Tasty.html#v:defaultMain)
- Many more...

Ideally we'll move to something better than `[IO Bool] -> IO ()` in the future, maybe with verbosity / color controls and parallel test running across test modules.