### PR TITLE
 Change Applicative GenT to use zipping

### DIFF
--- a/hedgehog-quickcheck/src/Test/QuickCheck/Hedgehog.hs
+++ b/hedgehog-quickcheck/src/Test/QuickCheck/Hedgehog.hs
@@ -8,9 +8,9 @@ import           Control.Monad.Trans.Maybe (runMaybeT)
 import           Data.Functor.Identity (runIdentity)
 
 import           Hedgehog
-import           Hedgehog.Internal.Gen (runGenT)
+import           Hedgehog.Internal.Gen (runGen)
 import qualified Hedgehog.Internal.Seed as Seed
-import           Hedgehog.Internal.Tree (Tree(..), Node(..))
+import           Hedgehog.Internal.Tree (NodeT(..), runTree)
 
 import qualified Test.QuickCheck as QuickCheck
 
@@ -33,10 +33,10 @@ hedgehog gen =
       else do
         seed <- genSeed
         size <- QuickCheck.sized (pure . fromIntegral)
-        case runIdentity . runMaybeT . runTree $ runGenT size seed gen of
+        case runGen size seed gen of
           Nothing ->
             loop (n - 1)
           Just x ->
-            pure $ nodeValue x
+            pure . nodeValue $ runTree x
   in
     loop (100 :: Int)

--- a/hedgehog-quickcheck/src/Test/QuickCheck/Hedgehog.hs
+++ b/hedgehog-quickcheck/src/Test/QuickCheck/Hedgehog.hs
@@ -4,9 +4,6 @@ module Test.QuickCheck.Hedgehog (
     hedgehog
   ) where
 
-import           Control.Monad.Trans.Maybe (runMaybeT)
-import           Data.Functor.Identity (runIdentity)
-
 import           Hedgehog
 import           Hedgehog.Internal.Gen (runGen)
 import qualified Hedgehog.Internal.Seed as Seed

--- a/hedgehog-test-laws/test/test.hs
+++ b/hedgehog-test-laws/test/test.hs
@@ -9,7 +9,7 @@ import           Data.Functor.Classes (Eq1(..))
 import           Hedgehog.Internal.Gen (GenT(..))
 import           Hedgehog.Internal.Range (Size(..))
 import           Hedgehog.Internal.Seed (Seed(..))
-import           Hedgehog.Internal.Tree (Tree(..), Node(..))
+import           Hedgehog.Internal.Tree (TreeT(..), NodeT(..))
 
 import           Test.QuickCheck (Arbitrary(..), Arbitrary1(..), CoArbitrary(..))
 import           Test.QuickCheck (choose, vector, coarbitraryIntegral, property)
@@ -32,20 +32,20 @@ instances =
       uncurry testProperties
   in
     testGroup "Instances" [
-      testGroup "Tree" $
+      testGroup "TreeT" $
         testBatch <$> [
-            applicative (undefined :: Tree Maybe (Bool, Char, Int))
-          , monad (undefined :: Tree Maybe (Bool, Char, Int))
-          , monadApplicative (undefined :: Tree (Either Bool) (Char, Int))
+            applicative (undefined :: TreeT Maybe (Bool, Char, Int))
+          , monad (undefined :: TreeT Maybe (Bool, Char, Int))
+          , monadApplicative (undefined :: TreeT (Either Bool) (Char, Int))
           ]
-    , testGroup "Node" $
+    , testGroup "NodeT" $
         testBatch <$> [
-            applicative (undefined :: Node Maybe (Bool, Char, Int))
-          , monad (undefined :: Node Maybe (Bool, Char, Int))
-          , monadApplicative (undefined :: Node (Either Bool) (Char, Int))
+            applicative (undefined :: NodeT Maybe (Bool, Char, Int))
+          , monad (undefined :: NodeT Maybe (Bool, Char, Int))
+          , monadApplicative (undefined :: NodeT (Either Bool) (Char, Int))
           ]
-    , ignoreTest . testGroup "GenT" $
-        testBatch <$> [
+    , testGroup "GenT" $
+        ignoreTest . testBatch <$> [
             applicative (undefined :: GenT Maybe (Bool, Char, Int))
           , monad (undefined :: GenT Maybe (Bool, Char, Int))
           , monadApplicative (undefined :: GenT (Either Bool) (Char, Int))
@@ -57,23 +57,23 @@ instances =
 
 -- Tree
 
-instance (Eq1 m, Eq a) => EqProp (Tree m a) where
+instance (Eq1 m, Eq a) => EqProp (TreeT m a) where
   (=-=) =
     eq
 
-instance (Arbitrary1 m, Arbitrary a) => Arbitrary (Tree m a) where
+instance (Arbitrary1 m, Arbitrary a) => Arbitrary (TreeT m a) where
   arbitrary =
-    Tree <$> arbitrary1
+    TreeT <$> arbitrary1
 
 -- Node
 
-instance (Eq1 m, Eq a) => EqProp (Node m a) where
+instance (Eq1 m, Eq a) => EqProp (NodeT m a) where
   (=-=) = eq
 
-instance (Arbitrary1 m, Arbitrary a) => Arbitrary (Node m a) where
+instance (Arbitrary1 m, Arbitrary a) => Arbitrary (NodeT m a) where
   arbitrary = do
     n <- choose (0, 2)
-    liftA2 Node arbitrary (vector n)
+    liftA2 NodeT arbitrary (vector n)
 
 -- GenT
 
@@ -93,7 +93,7 @@ instance (Arbitrary1 m) => Arbitrary1 (MaybeT m) where
   liftArbitrary = fmap MaybeT . liftArbitrary . liftArbitrary
 
 instance Show (GenT m a) where
-  show _ = "GenT { unGen = <function> }"
+  show _ = "GenT { unGenT = <function> }"
 
 instance (Eq1 m, Eq a) => EqProp (GenT m a) where
   GenT f0 =-= GenT f1 = property $ liftA2 (=-=) f0 f1

--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -133,6 +133,7 @@ test-suite test
   other-modules:
     Test.Hedgehog.Seed
     Test.Hedgehog.Text
+    Test.Hedgehog.Zip
 
   build-depends:
       hedgehog

--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -76,7 +76,7 @@ library
     , text                            >= 1.1        && < 1.3
     , th-lift                         >= 0.7        && < 0.8
     , time                            >= 1.4        && < 1.10
-    , transformers                    >= 0.4        && < 0.6
+    , transformers                    >= 0.5        && < 0.6
     , transformers-base               >= 0.4.5.1    && < 0.5
     , wl-pprint-annotated             >= 0.0        && < 0.2
 

--- a/hedgehog/src/Hedgehog/Internal/Gen.hs
+++ b/hedgehog/src/Hedgehog/Internal/Gen.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_HADDOCK not-home #-}
+{-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveFunctor #-}
@@ -123,15 +124,18 @@ module Hedgehog.Internal.Gen (
   , printTree
   , printWith
   , printTreeWith
+  , renderTree
 
   -- * Internal
   -- $internal
 
   -- ** Transfomer
+  , runGen
   , runGenT
   , mapGenT
   , generate
-  , liftTree
+  , liftTreeT
+  , liftTreeMaybeT
   , runDiscardEffect
 
   -- ** Size
@@ -148,9 +152,6 @@ module Hedgehog.Internal.Gen (
   , Vec(..)
   , Nat(..)
   , subtermMVec
-
-  -- ** Sampling
-  , renderNodes
   ) where
 
 import           Control.Applicative (Alternative(..),liftA2)
@@ -206,7 +207,7 @@ import           Hedgehog.Internal.Distributive (Distributive(..))
 import           Hedgehog.Internal.Seed (Seed)
 import qualified Hedgehog.Internal.Seed as Seed
 import qualified Hedgehog.Internal.Shrink as Shrink
-import           Hedgehog.Internal.Tree (Tree(..), Node(..))
+import           Hedgehog.Internal.Tree (TreeT(..), NodeT(..))
 import qualified Hedgehog.Internal.Tree as Tree
 import           Hedgehog.Range (Size, Range)
 import qualified Hedgehog.Range as Range
@@ -226,18 +227,18 @@ type Gen =
 --
 newtype GenT m a =
   GenT {
-      unGen :: Size -> Seed -> Tree (MaybeT m) a
+      unGenT :: Size -> Seed -> TreeT (MaybeT m) a
     }
 
 -- | Runs a generator, producing its shrink tree.
 --
-runGenT :: Size -> Seed -> GenT m a -> Tree (MaybeT m) a
+runGenT :: Size -> Seed -> GenT m a -> TreeT (MaybeT m) a
 runGenT size seed (GenT m) =
   m size seed
 
 -- | Map over a generator's shrink tree.
 --
-mapGenT :: (Tree (MaybeT m) a -> Tree (MaybeT n) b) -> GenT m a -> GenT n b
+mapGenT :: (TreeT (MaybeT m) a -> TreeT (MaybeT n) b) -> GenT m a -> GenT n b
 mapGenT f gen =
   GenT $ \size seed ->
     f (runGenT size seed gen)
@@ -245,16 +246,35 @@ mapGenT f gen =
 -- | Lift a predefined shrink tree in to a generator, ignoring the seed and the
 --   size.
 --
-liftTree :: Tree (MaybeT m) a -> GenT m a
-liftTree x =
+liftTreeT :: Monad m => TreeT m a -> GenT m a
+liftTreeT x =
+  GenT $ \_ _ ->
+    hoist (MaybeT . fmap Just) x
+
+-- | Lift a predefined shrink tree in to a generator, ignoring the seed and the
+--   size.
+--
+liftTreeMaybeT :: TreeT (MaybeT m) a -> GenT m a
+liftTreeMaybeT x =
   GenT (\_ _ -> x)
 
 -- | Run the discard effects through the tree and reify them as 'Maybe' values
 --   at the nodes. 'Nothing' means discarded, 'Just' means we have a value.
 --
-runDiscardEffect :: Monad m => Tree (MaybeT m) a -> Tree m (Maybe a)
+runDiscardEffect :: Monad m => TreeT (MaybeT m) a -> TreeT m (Maybe a)
 runDiscardEffect =
   runMaybeT . distribute
+
+-- | Run a generator, yielding its shrink tree.
+--
+--   'Nothing' means discarded, 'Just' means we have a value.
+--
+runGen :: Size -> Seed -> Gen a -> Maybe (TreeT Identity a)
+runGen size seed gen =
+  fmap (fmap Maybe.fromJust) .
+  Tree.filter Maybe.isJust .
+  runDiscardEffect $
+  runGenT size seed gen
 
 ------------------------------------------------------------------------
 -- MonadGen
@@ -308,12 +328,12 @@ instance Monad m => MonadGen (GenT m) where
 
   freezeGen gen =
     GenT $ \size seed -> do
-      mx <- Trans.lift . Trans.lift . runMaybeT . runTree $ runGenT size seed gen
+      mx <- Trans.lift . Trans.lift . runMaybeT . runTreeT $ runGenT size seed gen
       case mx of
         Nothing ->
           mzero
-        Just (Node x xs) ->
-          pure (x, liftTree . Tree.fromNode $ Node x xs)
+        Just (NodeT x xs) ->
+          pure (x, liftTreeMaybeT . Tree.fromNodeT $ NodeT x xs)
 
 instance MonadGen m => MonadGen (IdentityT m) where
   liftGen =
@@ -538,14 +558,18 @@ instance Functor m => Functor (GenT m) where
     GenT $ \seed size ->
       fmap f (runGenT seed size gen)
 
+--
+-- implementation: satisfies law (ap = <*>)
+--
 instance Monad m => Applicative (GenT m) where
   pure =
-    liftTree . pure
+    liftTreeMaybeT . pure
   (<*>) f m =
     GenT $ \ size seed ->
       case Seed.split seed of
         (sf, sm) ->
-          runGenT size sf f <*> runGenT size sm m
+          runGenT size sf f <*>
+          runGenT size sm m
 
 instance Monad m => Monad (GenT m) where
   return =
@@ -573,7 +597,7 @@ instance Monad m => Alternative (GenT m) where
 
 instance Monad m => MonadPlus (GenT m) where
   mzero =
-    liftTree mzero
+    liftTreeMaybeT mzero
 
   mplus x y =
     GenT $ \size seed ->
@@ -584,7 +608,7 @@ instance Monad m => MonadPlus (GenT m) where
 
 instance MonadTrans GenT where
   lift =
-    liftTree . Trans.lift . Trans.lift
+    liftTreeMaybeT . Trans.lift . Trans.lift
 
 instance MFunctor GenT where
   hoist f =
@@ -600,7 +624,7 @@ embedMaybe ::
 embedMaybe f m =
   Trans.lift . MaybeT . pure =<< f (runMaybeT m)
 
-embedTree :: Monad n => (forall a. m a -> Tree (MaybeT n) a) -> Tree (MaybeT m) b -> Tree (MaybeT n) b
+embedTree :: Monad n => (forall a. m a -> TreeT (MaybeT n) a) -> TreeT (MaybeT m) b -> TreeT (MaybeT n) b
 embedTree f tree =
   embed (embedMaybe f) tree
 
@@ -619,13 +643,13 @@ instance MMonad GenT where
 distributeGen :: Transformer t GenT m => GenT (t m) a -> t (GenT m) a
 distributeGen x =
   join . Trans.lift . GenT $ \size seed ->
-    pure . hoist liftTree . distribute . hoist distribute $ runGenT size seed x
+    pure . hoist liftTreeMaybeT . distribute . hoist distribute $ runGenT size seed x
 
 instance Distributive GenT where
   type Transformer t GenT m = (
       Monad (t (GenT m))
     , Transformer t MaybeT m
-    , Transformer t Tree (MaybeT m)
+    , Transformer t TreeT (MaybeT m)
     )
 
   distribute =
@@ -1555,45 +1579,13 @@ sample gen =
           error "Hedgehog.Gen.sample: too many discards, could not generate a sample"
         else do
           seed <- Seed.random
-          case runIdentity . runMaybeT . runTree $ runGenT 30 seed gen of
+          case runIdentity . runMaybeT . runTreeT $ runGenT 30 seed gen of
             Nothing ->
               loop (n - 1)
             Just x ->
               pure $ nodeValue x
     in
       loop (100 :: Int)
-
--- | Print the value produced by a generator, and the first level of shrinks,
---   for the given size and seed.
---
---   Use 'print' to generate a value from a random seed.
---
-printWith :: (MonadIO m, Show a) => Size -> Seed -> Gen a -> m ()
-printWith size seed gen =
-  liftIO $ do
-    let
-      Node x ss =
-        runIdentity . runTree $ renderNodes size seed gen
-
-    putStrLn "=== Outcome ==="
-    putStrLn x
-    putStrLn "=== Shrinks ==="
-
-    for_ ss $ \s ->
-      let
-        Node y _ =
-          runIdentity $ runTree s
-      in
-        putStrLn y
-
--- | Print the shrink tree produced by a generator, for the given size and
---   seed.
---
---   Use 'printTree' to generate a value from a random seed.
---
-printTreeWith :: (MonadIO m, Show a) => Size -> Seed -> Gen a -> m ()
-printTreeWith size seed gen = do
-  liftIO . putStr . runIdentity . Tree.render $ renderNodes size seed gen
 
 -- | Run a generator with a random seed and print the outcome, and the first
 --   level of shrinks.
@@ -1613,6 +1605,35 @@ print :: (MonadIO m, Show a) => Gen a -> m ()
 print gen = do
   seed <- liftIO Seed.random
   printWith 30 seed gen
+
+-- | Print the value produced by a generator, and the first level of shrinks,
+--   for the given size and seed.
+--
+--   Use 'print' to generate a value from a random seed.
+--
+printWith :: (MonadIO m, Show a) => Size -> Seed -> Gen a -> m ()
+printWith size seed gen =
+  liftIO $ do
+    case runGen size seed gen of
+      Nothing -> do
+        putStrLn "=== Outcome ==="
+        putStrLn "<discard>"
+
+      Just tree -> do
+        let
+          NodeT x ss =
+            runIdentity (runTreeT tree)
+
+        putStrLn "=== Outcome ==="
+        putStrLn (show x)
+        putStrLn "=== Shrinks ==="
+
+        for_ ss $ \s ->
+          let
+            NodeT y _ =
+              runIdentity $ runTreeT s
+          in
+            putStrLn (show y)
 
 -- | Run a generator with a random seed and print the resulting shrink tree.
 --
@@ -1636,11 +1657,26 @@ printTree gen = do
   seed <- liftIO Seed.random
   printTreeWith 30 seed gen
 
--- | Render a generator as a tree of strings.
+-- | Print the shrink tree produced by a generator, for the given size and
+--   seed.
 --
-renderNodes :: (Monad m, Show a) => Size -> Seed -> Gen a -> Tree m String
-renderNodes size seed =
-  fmap (Maybe.maybe "<discard>" show) . runDiscardEffect . runGenT size seed . lift
+--   Use 'printTree' to generate a value from a random seed.
+--
+printTreeWith :: (MonadIO m, Show a) => Size -> Seed -> Gen a -> m ()
+printTreeWith size seed gen = do
+  liftIO . putStr $
+    renderTree size seed gen
+
+-- | Render the shrink tree produced by a generator, for the given size and
+--   seed.
+--
+renderTree :: Show a => Size -> Seed -> Gen a -> String
+renderTree size seed gen =
+  case runGen size seed gen of
+    Nothing ->
+      "<discard>"
+    Just x ->
+      Tree.render (fmap show x)
 
 ------------------------------------------------------------------------
 -- Internal

--- a/hedgehog/src/Hedgehog/Internal/State.hs
+++ b/hedgehog/src/Hedgehog/Internal/State.hs
@@ -64,9 +64,7 @@ import           Control.Monad.Trans.State (StateT(..), evalStateT, runStateT)
 import           Data.Dynamic (Dynamic, toDyn, fromDynamic, dynTypeRep)
 import           Data.Foldable (traverse_)
 import           Data.Functor.Classes (Eq1(..), Ord1(..), Show1(..))
-#if MIN_VERSION_transformers(0,5,0)
 import           Data.Functor.Classes (eq1, compare1, showsPrec1)
-#endif
 import           Data.Map (Map)
 import qualified Data.Map as Map
 import qualified Data.Maybe as Maybe
@@ -114,7 +112,6 @@ instance Show (Symbolic a) where
   showsPrec p (Symbolic x) =
     showsPrec p x
 
-#if MIN_VERSION_transformers(0,5,0)
 instance Show1 Symbolic where
   liftShowsPrec _ _ p (Symbolic x) =
     showsPrec p x
@@ -126,19 +123,6 @@ instance Eq1 Symbolic where
 instance Ord1 Symbolic where
   liftCompare _ (Symbolic x) (Symbolic y) =
     compare x y
-#else
-instance Show1 Symbolic where
-  showsPrec1 p (Symbolic x) =
-    showsPrec p x
-
-instance Eq1 Symbolic where
-  eq1 (Symbolic x) (Symbolic y) =
-    x == y
-
-instance Ord1 Symbolic where
-  compare1 (Symbolic x) (Symbolic y) =
-    compare x y
-#endif
 
 -- | Concrete values: At test-execution time, 'Symbolic' values from generation
 --   are replaced with 'Concrete' values from performing actions. This type
@@ -153,7 +137,6 @@ instance Show a => Show (Concrete a) where
   showsPrec =
     showsPrec1
 
-#if MIN_VERSION_transformers(0,5,0)
 instance Show1 Concrete where
   liftShowsPrec sp _ p (Concrete x) =
     sp p x
@@ -165,19 +148,6 @@ instance Eq1 Concrete where
 instance Ord1 Concrete where
   liftCompare comp (Concrete x) (Concrete y) =
     comp x y
-#else
-instance Show1 Concrete where
-  showsPrec1 p (Concrete x) =
-    showsPrec p x
-
-instance Eq1 Concrete where
-  eq1 (Concrete x) (Concrete y) =
-    x == y
-
-instance Ord1 Concrete where
-  compare1 (Concrete x) (Concrete y) =
-    compare x y
-#endif
 
 ------------------------------------------------------------------------
 

--- a/hedgehog/src/Hedgehog/Internal/Tree.hs
+++ b/hedgehog/src/Hedgehog/Internal/Tree.hs
@@ -45,13 +45,9 @@ import           Control.Monad.Zip (MonadZip(..))
 
 import           Data.Functor.Identity (Identity(..))
 import           Data.Functor.Classes (Eq1(..))
-#if MIN_VERSION_base(4,9,0)
 import           Data.Functor.Classes (Show1(..), showsPrec1)
 import           Data.Functor.Classes (showsUnaryWith, showsBinaryWith)
-#endif
-import           Data.Foldable (Foldable(..))
 import           Data.Maybe (mapMaybe)
-import           Data.Monoid (mappend)
 
 import           Hedgehog.Internal.Distributive
 
@@ -156,11 +152,7 @@ instance Foldable Node where
 
 instance (Eq1 m, Eq a) => Eq (TreeT m a) where
   TreeT m0 == TreeT m1 =
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,5,0)
     liftEq (==) m0 m1
-#else
-    eq1 m0 m1
-#endif
 
 instance Functor m => Functor (NodeT m) where
   fmap f (NodeT x xs) =
@@ -384,7 +376,6 @@ instance MonadResource m => MonadResource (TreeT m) where
 ------------------------------------------------------------------------
 -- Show/Show1 instances
 
-#if MIN_VERSION_base(4,9,0)
 instance (Show1 m, Show a) => Show (NodeT m a) where
   showsPrec =
     showsPrec1
@@ -420,7 +411,6 @@ instance Show1 m => Show1 (TreeT m) where
         liftShowsPrec sp1 sl1
     in
       showsUnaryWith sp2 "TreeT" d m
-#endif
 
 ------------------------------------------------------------------------
 -- Pretty Printing

--- a/hedgehog/test/Test/Hedgehog/Zip.hs
+++ b/hedgehog/test/Test/Hedgehog/Zip.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Test.Hedgehog.Zip where
+
+import           Control.Monad.Zip (mzip)
+
+import           Data.Maybe (fromJust)
+import           Data.Foldable (toList)
+
+import           Hedgehog
+import qualified Hedgehog.Range as Range
+
+import qualified Hedgehog.Internal.Gen as Gen
+import           Hedgehog.Internal.Tree (Tree)
+import           Hedgehog.Internal.Source (HasCallStack, withFrozenCallStack)
+import qualified Hedgehog.Internal.Tree as Tree
+import qualified Hedgehog.Internal.Shrink as Shrink
+
+
+mkTree :: Int -> Tree Int
+mkTree n =
+  Tree.expand (Shrink.towards 0) (pure n)
+
+mkGen :: Int -> Gen Int
+mkGen =
+  Gen.liftTreeT . mkTree
+
+prop_gen_applicative :: Property
+prop_gen_applicative =
+  property $ do
+    let
+      treeApplicative n m =
+        (,) <$> mkTree n <*> mkTree m
+
+      treeZip n m =
+        mzip (mkTree n) (mkTree m)
+
+      genApplicative n m =
+        fromJust .
+        Gen.runGen 0 (Seed 0 0) $
+          (,) <$> mkGen n <*> mkGen m
+
+      count00 =
+        length .
+        filter (== (0,0)) .
+        toList
+
+      render :: HasCallStack => Tree (Int, Int) -> PropertyT IO ()
+      render x =
+        withFrozenCallStack $ do
+          annotate . Tree.render $ fmap show x
+          annotate $ "---"
+          annotate $ "count (0,0) = " ++ show (count00 x)
+
+    n <- forAll $ Gen.int (Range.constant 1 5)
+    m <- forAll $ Gen.int (Range.constant 1 5)
+
+    render $ genApplicative n m
+    render $ treeZip n m
+    render $ treeApplicative n m
+
+    genApplicative n m === treeZip n m
+    genApplicative n m /== treeApplicative n m
+
+    success
+
+tests :: IO Bool
+tests =
+  checkParallel $$(discover)

--- a/hedgehog/test/test.hs
+++ b/hedgehog/test/test.hs
@@ -2,6 +2,7 @@ import           Hedgehog.Main (defaultMain)
 
 import qualified Test.Hedgehog.Seed
 import qualified Test.Hedgehog.Text
+import qualified Test.Hedgehog.Zip
 
 
 main :: IO ()
@@ -9,4 +10,5 @@ main =
   defaultMain [
       Test.Hedgehog.Text.tests
     , Test.Hedgehog.Seed.tests
+    , Test.Hedgehog.Zip.tests
     ]


### PR DESCRIPTION
This changes the `Applicative` instance for `GenT` so that it [zips](https://github.com/well-typed/integrated-shrinking/blob/master/src/UsingHedgehog.hs#L255-L277) the tree rather than binding it. This means that a generator like `(,) <$> genA <*> genB` will be able to alternate between shrinking `genA` and `genB` rather than doing one first and then the other.

An example shrink tree using a zipping approach vs just using `(<*>) = ap`:

<img width="167" alt="Screenshot 2019-04-23 at 2 35 55 PM" src="https://user-images.githubusercontent.com/134805/56559936-a314ce80-65d5-11e9-9dfd-008cbf9e8949.png">

I had it like this originally and changed it because it broke the law `<*> = 
ap`, but I'm not sure this is that important as the `Monad` instance for `GenT` is already unlawful.

[Haxl](https://simonmar.github.io/bib/papers/haxl-icfp14.pdf) also uses an unlawful `Applicative` instance for basically the same reason. This was the motivation for `ApplicativeDo` which you would be able to use with Hedgehog after this patch to achieve more optimal shrinking.

A nice article explaining another option and the tradeoffs: https://elvishjerricco.github.io/2016/09/17/abstracting-async-concurrently.html

I also renamed `Tree` to `TreeT`, so I could have `Tree = TreeT Identity` as I was working with `TreeT Identity` a lot during testing and it got a bit tedious.