### PR TITLE
Drop support for GHC 7.10

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,17 +12,10 @@ environment:
   matrix:
     # We don't get many build bots with Appveyor so we only include the
     # latest for each major version.
-    - GHC_VERSION: "8.6.4"
-    #- GHC_VERSION: "8.6.3"
-    #- GHC_VERSION: "8.6.2"
-    #- GHC_VERSION: "8.6.1"
-    - GHC_VERSION: "8.4.4"
-    #- GHC_VERSION: "8.4.3"
-    #- GHC_VERSION: "8.4.2"
-    #- GHC_VERSION: "8.4.1"
-    - GHC_VERSION: "8.2.2"
     - GHC_VERSION: "8.0.2"
-    #- GHC_VERSION: "8.0.1"
+    - GHC_VERSION: "8.2.2"
+    - GHC_VERSION: "8.4.4"
+    - GHC_VERSION: "8.6.4"
 
 cache:
  - "C:\\SR"

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,32 +30,15 @@ before_cache:
 
 matrix:
   include:
-    - compiler: "ghc-8.6.4"
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.6.4], sources: [hvr-ghc]}}
-    - compiler: "ghc-8.6.3"
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.6.3], sources: [hvr-ghc]}}
-    - compiler: "ghc-8.6.2"
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.6.2], sources: [hvr-ghc]}}
-    - compiler: "ghc-8.6.1"
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.6.1], sources: [hvr-ghc]}}
-    - compiler: "ghc-8.4.4"
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.4.4], sources: [hvr-ghc]}}
-    - compiler: "ghc-8.4.3"
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.4.3], sources: [hvr-ghc]}}
-    - compiler: "ghc-8.4.2"
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.4.2], sources: [hvr-ghc]}}
-    - compiler: "ghc-8.4.1"
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.4.1], sources: [hvr-ghc]}}
-    - compiler: "ghc-8.2.2"
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.2.2], sources: [hvr-ghc]}}
+    # check the oldest versions first as they're most likely to fail.
     - compiler: "ghc-8.0.2"
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.0.2], sources: [hvr-ghc]}}
-    - compiler: "ghc-8.0.1"
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.0.1], sources: [hvr-ghc]}}
-    - compiler: "ghc-7.10.3"
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-7.10.3], sources: [hvr-ghc]}}
-    - compiler: "ghc-7.10.2"
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-7.10.2], sources: [hvr-ghc]}}
+    - compiler: "ghc-8.2.2"
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.2.2], sources: [hvr-ghc]}}
+    - compiler: "ghc-8.4.4"
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.4.4], sources: [hvr-ghc]}}
+    - compiler: "ghc-8.6.4"
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.6.4], sources: [hvr-ghc]}}
 
 before_install:
   - HC=/opt/ghc/bin/${CC}
@@ -143,15 +126,6 @@ script:
 
   # Build without installed constraints for packages in global-db
   - rm -f cabal.project.local; ${CABAL} new-build -w ${HC} --disable-tests --disable-benchmarks all
-
-branches:
-  only:
-    # This is where pull requests from "bors r+" are built.
-    - staging
-    # This is where pull requests from "bors try" are built.
-    - trying
-    # Comment this to disable building pull requests.
-    - master
 
 # REGENDATA ["cabal.project"]
 # EOF

--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -30,18 +30,9 @@ cabal-version:
 build-type:
   Simple
 tested-with:
-    GHC == 7.10.2
-  , GHC == 7.10.3
-  , GHC == 8.0.1
-  , GHC == 8.0.2
+    GHC == 8.0.2
   , GHC == 8.2.2
-  , GHC == 8.4.1
-  , GHC == 8.4.2
-  , GHC == 8.4.3
   , GHC == 8.4.4
-  , GHC == 8.6.1
-  , GHC == 8.6.2
-  , GHC == 8.6.3
   , GHC == 8.6.4
 extra-source-files:
   README.md
@@ -53,7 +44,8 @@ source-repository head
 
 library
   build-depends:
-      base                            >= 3          && < 5
+   -- GHC 8.0.1 / base-4.9.0.0 (May 2016)
+      base                            >= 4.9        && < 5
     , ansi-terminal                   >= 0.6        && < 0.10
     , async                           >= 2.0        && < 2.3
     , bytestring                      >= 0.10       && < 0.11
@@ -74,7 +66,6 @@ library
     , stm                             >= 2.4        && < 2.6
     , template-haskell                >= 2.10       && < 2.15
     , text                            >= 1.1        && < 1.3
-    , th-lift                         >= 0.7        && < 0.8
     , time                            >= 1.4        && < 1.10
     , transformers                    >= 0.5        && < 0.6
     , transformers-base               >= 0.4.5.1    && < 0.5

--- a/hedgehog/src/Hedgehog/Internal/Config.hs
+++ b/hedgehog/src/Hedgehog/Internal/Config.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_HADDOCK not-home #-}
+{-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE DoAndIfThenElse #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
@@ -24,7 +25,7 @@ import           Control.Monad.IO.Class (MonadIO(..))
 
 import qualified GHC.Conc as Conc
 
-import           Language.Haskell.TH.Lift (deriveLift)
+import           Language.Haskell.TH.Syntax (Lift)
 
 import           System.Console.ANSI (hSupportsANSI)
 import           System.Environment (lookupEnv)
@@ -40,7 +41,7 @@ data UseColor =
     -- ^ Disable ANSI colors in report output.
   | EnableColor
     -- ^ Enable ANSI colors in report output.
-    deriving (Eq, Ord, Show)
+    deriving (Eq, Ord, Show, Lift)
 
 -- | How verbose should the report output be.
 --
@@ -49,13 +50,13 @@ data Verbosity =
     -- ^ Only display the summary of the test run.
   | Normal
     -- ^ Display each property as it is running, as well as the summary.
-    deriving (Eq, Ord, Show)
+    deriving (Eq, Ord, Show, Lift)
 
 -- | The number of workers to use when running properties in parallel.
 --
 newtype WorkerCount =
   WorkerCount Int
-  deriving (Eq, Ord, Show, Num, Enum, Real, Integral)
+  deriving (Eq, Ord, Show, Num, Enum, Real, Integral, Lift)
 
 detectMark :: MonadIO m => m Bool
 detectMark = do
@@ -154,10 +155,3 @@ resolveWorkers = \case
     detectWorkers
   Just x ->
     pure x
-
-------------------------------------------------------------------------
--- FIXME Replace with DeriveLift when we drop 7.10 support.
-
-$(deriveLift ''UseColor)
-$(deriveLift ''Verbosity)
-$(deriveLift ''WorkerCount)

--- a/hedgehog/src/Hedgehog/Internal/Gen.hs
+++ b/hedgehog/src/Hedgehog/Internal/Gen.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_HADDOCK not-home #-}
+{-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveFunctor #-}

--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -1,7 +1,9 @@
 {-# OPTIONS_HADDOCK not-home #-}
+{-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveFoldable #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE DoAndIfThenElse #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -151,7 +153,7 @@ import qualified Hedgehog.Internal.Gen as Gen
 import           Hedgehog.Internal.Show
 import           Hedgehog.Internal.Source
 
-import           Language.Haskell.TH.Lift (deriveLift)
+import           Language.Haskell.TH.Syntax (Lift)
 
 ------------------------------------------------------------------------
 
@@ -217,7 +219,7 @@ newtype TestT m a =
 newtype PropertyName =
   PropertyName {
       unPropertyName :: String
-    } deriving (Eq, Ord, Show, IsString, Semigroup)
+    } deriving (Eq, Ord, Show, IsString, Semigroup, Lift)
 
 -- | Configuration for a property test.
 --
@@ -227,7 +229,7 @@ data PropertyConfig =
     , propertyDiscardLimit :: !DiscardLimit
     , propertyShrinkLimit :: !ShrinkLimit
     , propertyShrinkRetries :: !ShrinkRetries
-    } deriving (Eq, Ord, Show)
+    } deriving (Eq, Ord, Show, Lift)
 
 -- | The number of successful tests that need to be run before a property test
 --   is considered successful.
@@ -240,7 +242,7 @@ data PropertyConfig =
 --
 newtype TestLimit =
   TestLimit Int
-  deriving (Eq, Ord, Show, Num, Enum, Real, Integral)
+  deriving (Eq, Ord, Show, Num, Enum, Real, Integral, Lift)
 
 -- | The number of tests a property ran successfully.
 --
@@ -265,7 +267,7 @@ newtype DiscardCount =
 --
 newtype DiscardLimit =
   DiscardLimit Int
-  deriving (Eq, Ord, Show, Num, Enum, Real, Integral)
+  deriving (Eq, Ord, Show, Num, Enum, Real, Integral, Lift)
 
 -- | The number of shrinks to try before giving up on shrinking.
 --
@@ -277,7 +279,7 @@ newtype DiscardLimit =
 --
 newtype ShrinkLimit =
   ShrinkLimit Int
-  deriving (Eq, Ord, Show, Num, Enum, Real, Integral)
+  deriving (Eq, Ord, Show, Num, Enum, Real, Integral, Lift)
 
 -- | The numbers of times a property was able to shrink after a failing test.
 --
@@ -302,7 +304,7 @@ newtype ShrinkCount =
 --
 newtype ShrinkRetries =
   ShrinkRetries Int
-  deriving (Eq, Ord, Show, Num, Enum, Real, Integral)
+  deriving (Eq, Ord, Show, Num, Enum, Real, Integral, Lift)
 
 -- | A named collection of property tests.
 --
@@ -323,7 +325,7 @@ data Group =
 newtype GroupName =
   GroupName {
       unGroupName :: String
-    } deriving (Eq, Ord, Show, IsString, Semigroup)
+    } deriving (Eq, Ord, Show, IsString, Semigroup, Lift)
 
 -- | The number of properties in a group.
 --
@@ -1100,17 +1102,6 @@ collect :: (MonadTest m, Show a, HasCallStack) => a -> m ()
 collect x =
   withFrozenCallStack $
     cover 0 (LabelName (show x)) True
-
-------------------------------------------------------------------------
--- FIXME Replace with DeriveLift when we drop 7.10 support.
-
-$(deriveLift ''GroupName)
-$(deriveLift ''PropertyName)
-$(deriveLift ''PropertyConfig)
-$(deriveLift ''TestLimit)
-$(deriveLift ''DiscardLimit)
-$(deriveLift ''ShrinkLimit)
-$(deriveLift ''ShrinkRetries)
 
 ------------------------------------------------------------------------
 -- Internal

--- a/hedgehog/src/Hedgehog/Internal/Report.hs
+++ b/hedgehog/src/Hedgehog/Internal/Report.hs
@@ -67,6 +67,7 @@ import           System.Console.ANSI (ColorIntensity(..), Color(..))
 import           System.Console.ANSI (ConsoleLayer(..), ConsoleIntensity(..))
 import           System.Console.ANSI (SGR(..), setSGRCode)
 import           System.Directory (makeRelativeToCurrentDirectory)
+
 #if mingw32_HOST_OS
 import           System.IO (hSetEncoding, stdout, stderr, utf8)
 #endif

--- a/hedgehog/src/Hedgehog/Internal/Runner.hs
+++ b/hedgehog/src/Hedgehog/Internal/Runner.hs
@@ -1,6 +1,7 @@
 {-# OPTIONS_HADDOCK not-home #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE DoAndIfThenElse #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
@@ -48,7 +49,7 @@ import qualified Hedgehog.Internal.Seed as Seed
 import           Hedgehog.Internal.Tree (TreeT(..), NodeT(..))
 import           Hedgehog.Range (Size)
 
-import           Language.Haskell.TH.Lift (deriveLift)
+import           Language.Haskell.TH.Syntax (Lift)
 
 #if mingw32_HOST_OS
 import           System.IO (hSetEncoding, stdout, stderr, utf8)
@@ -69,7 +70,7 @@ data RunnerConfig =
       -- | How verbose to be in the runner output. 'Nothing' means detect from
       --   the environment.
     , runnerVerbosity :: !(Maybe Verbosity)
-    } deriving (Eq, Ord, Show)
+    } deriving (Eq, Ord, Show, Lift)
 
 findM :: Monad m => [a] -> b -> (a -> m (Maybe b)) -> m b
 findM xs0 def p =
@@ -431,8 +432,3 @@ checkParallel =
       , runnerVerbosity =
           Nothing
       }
-
-------------------------------------------------------------------------
--- FIXME Replace with DeriveLift when we drop 7.10 support.
-
-$(deriveLift ''RunnerConfig)

--- a/hedgehog/src/Hedgehog/Internal/Source.hs
+++ b/hedgehog/src/Hedgehog/Internal/Source.hs
@@ -18,12 +18,9 @@ module Hedgehog.Internal.Source (
   , withFrozenCallStack
   ) where
 
-#if MIN_VERSION_base(4,9,0)
 import GHC.Stack (CallStack, HasCallStack, SrcLoc(..))
 import GHC.Stack (callStack, getCallStack, withFrozenCallStack)
-#else
-import GHC.Exts (Constraint)
-#endif
+
 
 newtype LineNo =
   LineNo {
@@ -44,25 +41,7 @@ data Span =
     , spanEndColumn :: !ColumnNo
     } deriving (Eq, Ord)
 
-#if !MIN_VERSION_base(4,9,0)
-type family HasCallStack :: Constraint where
-  HasCallStack = ()
-
-data CallStack =
-  CallStack
-  deriving (Show)
-
-callStack :: HasCallStack => CallStack
-callStack =
-  CallStack
-
-withFrozenCallStack :: HasCallStack => (HasCallStack => a) -> a
-withFrozenCallStack x =
-  x
-#endif
-
 getCaller :: CallStack -> Maybe Span
-#if MIN_VERSION_base(4,9,0)
 getCaller stack =
   case getCallStack stack of
     [] ->
@@ -74,10 +53,6 @@ getCaller stack =
         (fromIntegral $ srcLocStartCol x)
         (fromIntegral $ srcLocEndLine x)
         (fromIntegral $ srcLocEndCol x)
-#else
-getCaller _ =
-  Nothing
-#endif
 
 ------------------------------------------------------------------------
 -- Show instances


### PR DESCRIPTION
I keep running up against compatibility issues, and I think it's old enough now.

We'll still have support for GHC 8.01, which is three years old now.