### PR TITLE
Fix filter shrinking bug #281

### DIFF
--- a/hedgehog/src/Hedgehog/Internal/State.hs
+++ b/hedgehog/src/Hedgehog/Internal/State.hs
@@ -537,7 +537,7 @@ action ::
   => [Command gen m state]
   -> GenT (StateT (Context state) (GenBase gen)) (Action m state)
 action commands =
-  Gen.just $ do
+  Gen.justT $ do
     Context state0 _ <- get
 
     Command mgenInput exec callbacks <-

--- a/hedgehog/test/Test/Hedgehog/Filter.hs
+++ b/hedgehog/test/Test/Hedgehog/Filter.hs
@@ -1,0 +1,105 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE FlexibleContexts #-}
+module Test.Hedgehog.Filter where
+
+import           Control.Monad (join)
+import           Control.Monad.Trans.Maybe (MaybeT(..))
+import           Control.Monad.Morph (hoist, generalize)
+
+import           Data.Foldable (toList)
+import           Data.Functor.Identity (Identity(..))
+import qualified Data.Set as Set
+
+import           Hedgehog
+import qualified Hedgehog.Range as Range
+
+import qualified Hedgehog.Internal.Gen as Gen
+import qualified Hedgehog.Internal.Shrink as Shrink
+import           Hedgehog.Internal.Source (HasCallStack, withFrozenCallStack)
+import           Hedgehog.Internal.Tree (Tree, TreeT(..), NodeT(..))
+import qualified Hedgehog.Internal.Tree as Tree
+
+-- | Prevent this bug from returning:
+--
+--   https://stackoverflow.com/questions/54412108/why-the-does-this-shrink-tree-looks-the-way-it-does-when-using-filter
+--
+--   I'm trying to understand what is the effect that filter has in the shrink
+--   tree of a generator when using _integrated shrinking_.
+--
+--   Consider the following function:
+--
+-- @
+--   {-# LANGUAGE OverloadedStrings #-}
+--
+--   import Hedgehog
+--   import qualified Hedgehog.Gen as Gen
+--
+--   genChar:: Gen Char
+--   genChar =
+--     Gen.filter (`elem` ("x" :: String)) (Gen.element "yx")
+--
+-- @
+--
+--   When a print the shrink tree:
+--
+-- @
+--   >>>  Gen.printTree genChar
+-- @
+--
+--   I'd get shrink trees that look as follow:
+--
+-- @
+--   'x'
+--    └╼'x'
+--       └╼'x'
+--          └╼'x'
+--                  ...
+--
+--                      └╼<discard>
+-- @
+--
+--   This is, a very deep tree containing only @x@'s, and a @discard@ at the
+--   end.
+--
+prop_filter_repetition :: Property
+prop_filter_repetition =
+  property $ do
+    let
+      genChar:: Gen Char
+      genChar =
+        Gen.filter (`elem` ("x" :: String)) (Gen.element "yx")
+
+    tree <- forAllWith (Tree.render . fmap show . Tree.prune 10) (Gen.toTree genChar)
+    Tree.depth tree === 1
+
+prop_filter_even :: Property
+prop_filter_even =
+  property $ do
+    let
+      genEven :: Gen Int
+      genEven =
+        Gen.filter even (Gen.int (Range.constant 0 8))
+
+    tree <- forAllWith (Tree.render . fmap show . Tree.prune 5) (Gen.toTree genEven)
+
+    let
+      NodeT x _ =
+        Tree.runTree tree
+
+      required =
+        Set.fromList (filter even [0..x])
+
+      actual =
+        Set.fromList (toList tree)
+
+      missing =
+        required `Set.difference` actual
+
+    annotateShow missing
+    required === actual
+    failure
+
+tests :: IO Bool
+tests =
+  checkParallel $$(discover)


### PR DESCRIPTION
This implements @edsko's ideas from #281. I made the default `filter` the "ideal" one presented last in that issue, it just requires that the base `Monad` is `Identity` which I would expect to be the case 100% of the time when using `filter`. The faster one is `filterT` and can be used with any base `Monad`, I'm not sure if this should even be included. It is indeed faster but i'm not sure if that's so important?