### PR TITLE
Fixed state machine duplicate Vars when shrinking

### DIFF
--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -122,6 +122,8 @@ test-suite test
     test
 
   other-modules:
+    Test.Hedgehog.Applicative
+    Test.Hedgehog.Filter
     Test.Hedgehog.Seed
     Test.Hedgehog.Text
     Test.Hedgehog.Zip
@@ -130,6 +132,7 @@ test-suite test
       hedgehog
     , base                            >= 3          && < 5
     , containers                      >= 0.4        && < 0.7
+    , mmorph                          >= 1.0        && < 1.2
     , mtl                             >= 2.1        && < 2.3
     , pretty-show                     >= 1.6        && < 1.10
     , semigroups                      >= 0.16       && < 0.19

--- a/hedgehog/src/Hedgehog/Internal/State.hs
+++ b/hedgehog/src/Hedgehog/Internal/State.hs
@@ -71,6 +71,7 @@ import qualified Data.Map as Map
 import qualified Data.Maybe as Maybe
 import           Data.Typeable (Typeable, TypeRep, Proxy(..), typeRep)
 
+import           Hedgehog.Internal.Distributive (distributeT)
 import           Hedgehog.Internal.Gen (MonadGen, GenT, GenBase)
 import qualified Hedgehog.Internal.Gen as Gen
 import           Hedgehog.Internal.HTraversable (HTraversable(..))
@@ -572,7 +573,7 @@ genActions ::
   -> Context state
   -> gen ([Action m state], Context state)
 genActions range commands ctx = do
-  xs <- Gen.fromGenT . hoist (`evalStateT` ctx) $ Gen.list range (action commands)
+  xs <- Gen.fromGenT . (`evalStateT` ctx) . distributeT $ Gen.list range (action commands)
   pure $
     dropInvalid xs `runState` ctx
 

--- a/hedgehog/src/Hedgehog/Internal/Tree.hs
+++ b/hedgehog/src/Hedgehog/Internal/Tree.hs
@@ -334,6 +334,14 @@ instance Foldable Node where
   foldMap f (NodeT x xs) =
     f x `mappend` mconcat (fmap (foldMap f) xs)
 
+instance Traversable Tree where
+  traverse f (TreeT mx) =
+    TreeT <$> traverse (traverse f) mx
+
+instance Traversable Node where
+  traverse f (NodeT x xs) =
+    NodeT <$> f x <*> traverse (traverse f) xs
+
 ------------------------------------------------------------------------
 -- NodeT/TreeT instances
 

--- a/hedgehog/test/Test/Hedgehog/Applicative.hs
+++ b/hedgehog/test/Test/Hedgehog/Applicative.hs
@@ -1,0 +1,97 @@
+{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeOperators #-}
+module Test.Hedgehog.Applicative where
+
+import           Control.Monad.Morph (hoist)
+import           Control.Monad.State.Class (MonadState(..), modify)
+import qualified Control.Monad.Trans.State.Lazy as Lazy
+
+import           Data.Foldable (traverse_)
+import qualified Data.List as List
+import qualified Data.Map as Map
+
+import           Hedgehog hiding (Command, Var)
+import qualified Hedgehog.Range as Range
+
+import qualified Hedgehog.Internal.Gen as Gen
+import qualified Hedgehog.Internal.Tree as Tree
+
+
+newtype Var =
+  Var Int
+  deriving (Eq, Ord, Show)
+
+data Command =
+    Add
+  | Remove
+    deriving (Eq, Ord, Show)
+
+data a :<- b =
+  a :<- b
+  deriving (Eq, Ord, Show)
+
+takeVar :: a :<- b -> a
+takeVar (var :<- _) =
+  var
+
+genVar :: (MonadState Int m, MonadGen m) => m Var
+genVar = do
+  modify (+1)
+  Var <$> get
+
+genCommand :: MonadGen m => m Command
+genCommand =
+  Gen.element [Add, Remove]
+
+genCommands :: (MonadState Int m, MonadGen m) => m [Var :<- Command]
+genCommands =
+  Gen.list (Range.constant 0 3) $ do
+    var <- genVar
+    cmd <- genCommand
+    pure $
+      var :<- cmd
+
+-- | Uncomment to observe invalid Applicative behaviour
+--
+--   /This actually also works, if you comment out the ApplicativeDo above./
+--
+xprop_StateT_inside :: Property
+xprop_StateT_inside =
+  propVars $ hoist (`Lazy.evalStateT` 0) genCommands
+
+prop_StateT_outside :: Property
+prop_StateT_outside =
+  propVars . (`Lazy.evalStateT` 0) $ distributeT genCommands
+
+propVars :: Gen [Var :<- Command] -> Property
+propVars gen =
+  property $ do
+    let
+
+    tree <-
+      forAllWith (Tree.render . fmap show . Tree.prune 3) $
+        Gen.toTree gen
+
+    let
+      noDuplicates xs =
+        let
+          sorted =
+            List.sort xs
+
+          unique =
+            Map.elems (Map.fromList (fmap (\x -> (takeVar x, x)) xs))
+
+          varsEq ys zs =
+            fmap takeVar ys ==
+            fmap takeVar zs
+        in
+          diff sorted varsEq unique
+
+    traverse_ noDuplicates tree
+
+tests :: IO Bool
+tests =
+  checkParallel $$(discover)

--- a/hedgehog/test/Test/Hedgehog/Filter.hs
+++ b/hedgehog/test/Test/Hedgehog/Filter.hs
@@ -3,21 +3,14 @@
 {-# LANGUAGE FlexibleContexts #-}
 module Test.Hedgehog.Filter where
 
-import           Control.Monad (join)
-import           Control.Monad.Trans.Maybe (MaybeT(..))
-import           Control.Monad.Morph (hoist, generalize)
-
 import           Data.Foldable (toList)
-import           Data.Functor.Identity (Identity(..))
 import qualified Data.Set as Set
 
 import           Hedgehog
 import qualified Hedgehog.Range as Range
 
 import qualified Hedgehog.Internal.Gen as Gen
-import qualified Hedgehog.Internal.Shrink as Shrink
-import           Hedgehog.Internal.Source (HasCallStack, withFrozenCallStack)
-import           Hedgehog.Internal.Tree (Tree, TreeT(..), NodeT(..))
+import           Hedgehog.Internal.Tree (NodeT(..))
 import qualified Hedgehog.Internal.Tree as Tree
 
 -- | Prevent this bug from returning:
@@ -98,7 +91,6 @@ prop_filter_even =
 
     annotateShow missing
     required === actual
-    failure
 
 tests :: IO Bool
 tests =

--- a/hedgehog/test/test.hs
+++ b/hedgehog/test/test.hs
@@ -1,5 +1,7 @@
 import           Hedgehog.Main (defaultMain)
 
+import qualified Test.Hedgehog.Applicative
+import qualified Test.Hedgehog.Filter
 import qualified Test.Hedgehog.Seed
 import qualified Test.Hedgehog.Text
 import qualified Test.Hedgehog.Zip
@@ -8,7 +10,9 @@ import qualified Test.Hedgehog.Zip
 main :: IO ()
 main =
   defaultMain [
-      Test.Hedgehog.Text.tests
+      Test.Hedgehog.Applicative.tests
+    , Test.Hedgehog.Filter.tests
     , Test.Hedgehog.Seed.tests
+    , Test.Hedgehog.Text.tests
     , Test.Hedgehog.Zip.tests
     ]


### PR DESCRIPTION
Running a `StateT` on the inside of `GenT` doesn't work properly with the new applicative implementation, so we `distributeT` to move it to the outside before running it.

It has to be on the inside, because otherwise it's not a `MonadGen`, due to the new list shrinking code. It does seem kind of odd that I can't make it work on the outside, it must be possible.