### PR TITLE
Document the use case for 'test' and improve 'ResourceT' example.

### DIFF
--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -874,14 +874,9 @@ discard =
 --   instance at the expense of not being able to generate additional inputs
 --   using 'forAll'.
 --
---   One use case for this is writing tests which use 'ResourceT':
---
--- @
---   property $ do
---     n <- forAll $ Gen.int64 Range.linearBounded
---     test . runResourceT $ do
---       -- test with resource usage here
--- @
+--   An example where this is useful is parallel state machine testing, as
+--   'Hedgehog.Internal.State.executeParallel' requires 'MonadBaseControl' 'IO'
+--   in order to be able to spawn threads in 'MonadTest'.
 --
 test :: Monad m => TestT m a -> PropertyT m a
 test =


### PR DESCRIPTION
As noted in https://github.com/hedgehogqa/haskell-hedgehog/issues/284, the documentation for `Hedgehog.test` is wrong. This updates that and also adds an example for observing when certain actions are run during the testing and shrinking process for those who are interested.