### PR TITLE
Fix -Wunused-imports warning on Windows/MinGW

### DIFF
--- a/hedgehog/src/Hedgehog/Main.hs
+++ b/hedgehog/src/Hedgehog/Main.hs
@@ -7,12 +7,7 @@ module Hedgehog.Main (
 import           Control.Monad (unless)
 
 import           System.Exit (exitFailure)
-
-#if mingw32_HOST_OS
-import           System.IO (BufferMode (LineBuffering), hSetBuffering, hSetEncoding, stdout, stderr, utf8)
-#else
 import           System.IO (BufferMode (LineBuffering), hSetBuffering, stderr, stdout)
-#endif
 
 -- | An entry point that can be used as a main function.
 --


### PR DESCRIPTION
Makes this go away (trimmed to fit into 80 chars width):

```
..\hedgehog\src\Hedgehog\Main.hs:12:1: warning: [-Wunused-imports]
    The import of `hSetEncoding, utf8'
    from module `System.IO' is redundant
   |
12 | import           System.IO (BufferMode (LineBuffering), hSetBuffering, hSetEncoding, std...
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```