### PR TITLE
Statistically verify result

### DIFF
--- a/hedgehog-example/hedgehog-example.cabal
+++ b/hedgehog-example/hedgehog-example.cabal
@@ -43,6 +43,7 @@ library
 
   exposed-modules:
       Test.Example.Basic
+    , Test.Example.Confidence
     , Test.Example.Coverage
     , Test.Example.Exception
     , Test.Example.List

--- a/hedgehog-example/src/Test/Example/Confidence.hs
+++ b/hedgehog-example/src/Test/Example/Confidence.hs
@@ -10,11 +10,14 @@ import qualified Hedgehog.Internal.Gen as Gen
 -- Example 0: This test will certify that it is impossible to get 100%
 --            coverage for the property label "number == 1"
 --
+--            Note that it will abort running once it knows its task is
+--            impossible - it will not run 1000000 tests
+--
 prop_without_confidence :: Property
 prop_without_confidence =
-  withConfidence (10^9) . withTests 100 . property $ do
+  withConfidence (10^9) . withTests 1000000 . property $ do
     number <- forAll (Gen.int $ Range.linear 1 10)
-    cover 100 "number == 1" $ number == 1
+    cover 60 "number == 1" $ number == 1
 
 ------------------------------------------------------------------------
 tests :: IO Bool

--- a/hedgehog-example/src/Test/Example/Confidence.hs
+++ b/hedgehog-example/src/Test/Example/Confidence.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Test.Example.Confidence where
+
+import           Hedgehog
+import qualified Hedgehog.Range as Range
+import qualified Hedgehog.Internal.Gen as Gen
+
+------------------------------------------------------------------------
+-- Example 0: This test will certify that it is impossible to get 100%
+--            coverage for the property label "number == 1"
+--
+prop_without_confidence :: Property
+prop_without_confidence =
+  withConfidence (10^9) . withTests 100 . property $ do
+    number <- forAll (Gen.int $ Range.linear 1 10)
+    cover 100 "number == 1" $ number == 1
+
+------------------------------------------------------------------------
+tests :: IO Bool
+tests =
+  checkSequential $$(discover)

--- a/hedgehog-example/src/Test/Example/Confidence.hs
+++ b/hedgehog-example/src/Test/Example/Confidence.hs
@@ -16,7 +16,7 @@ import qualified Hedgehog.Internal.Gen as Gen
 prop_without_confidence :: Property
 prop_without_confidence =
   withConfidence (10^9) . withTests 1000000 . property $ do
-    number <- forAll (Gen.int $ Range.linear 1 10)
+    number <- forAll (Gen.int $ Range.constant 1 2)
     cover 60 "number == 1" $ number == 1
 
 ------------------------------------------------------------------------

--- a/hedgehog-example/src/Test/Example/Confidence.hs
+++ b/hedgehog-example/src/Test/Example/Confidence.hs
@@ -15,7 +15,7 @@ import qualified Hedgehog.Internal.Gen as Gen
 --
 prop_without_confidence :: Property
 prop_without_confidence =
-  withConfidence (10^9) . withTests 1000000 . property $ do
+  terminateEarly . withConfidence (10^9) . withTests 1000000 . property $ do
     number <- forAll (Gen.int $ Range.constant 1 2)
     cover 60 "number == 1" $ number == 1
 

--- a/hedgehog-example/src/Test/Example/Confidence.hs
+++ b/hedgehog-example/src/Test/Example/Confidence.hs
@@ -15,7 +15,7 @@ import qualified Hedgehog.Internal.Gen as Gen
 --
 prop_without_confidence :: Property
 prop_without_confidence =
-  terminateEarly . withConfidence (10^9) . withTests 1000000 . property $ do
+  verifiedTermination . withConfidence (10^9) . withTests 1000000 . property $ do
     number <- forAll (Gen.int $ Range.constant 1 2)
     cover 60 "number == 1" $ number == 1
 

--- a/hedgehog-example/src/Test/Example/Confidence.hs
+++ b/hedgehog-example/src/Test/Example/Confidence.hs
@@ -7,7 +7,7 @@ import qualified Hedgehog.Range as Range
 import qualified Hedgehog.Internal.Gen as Gen
 
 ------------------------------------------------------------------------
--- Example 0: This test will certify that it is impossible to get 100%
+-- Example 0: This test will certify that it is impossible to get 60%
 --            coverage for the property label "number == 1"
 --
 --            Note that it will abort running once it knows its task is

--- a/hedgehog-example/test/test.hs
+++ b/hedgehog-example/test/test.hs
@@ -1,14 +1,15 @@
 import           System.IO (BufferMode(..), hSetBuffering, stdout, stderr)
 
-import qualified Test.Example.Basic as Test.Example.Basic
-import qualified Test.Example.Coverage as Test.Example.Coverage
-import qualified Test.Example.Exception as Test.Example.Exception
-import qualified Test.Example.QuickCheck as Test.Example.QuickCheck
-import qualified Test.Example.References as Test.Example.References
-import qualified Test.Example.Registry as Test.Example.Registry
-import qualified Test.Example.Resource as Test.Example.Resource
-import qualified Test.Example.Roundtrip as Test.Example.Roundtrip
-import qualified Test.Example.STLC as Test.Example.STLC
+import qualified Test.Example.Basic
+import qualified Test.Example.Confidence
+import qualified Test.Example.Coverage
+import qualified Test.Example.Exception
+import qualified Test.Example.QuickCheck
+import qualified Test.Example.References
+import qualified Test.Example.Registry
+import qualified Test.Example.Resource
+import qualified Test.Example.Roundtrip
+import qualified Test.Example.STLC
 
 main :: IO ()
 main = do
@@ -17,6 +18,7 @@ main = do
 
   _results <- sequence [
       Test.Example.Basic.tests
+    , Test.Example.Confidence.tests
     , Test.Example.Coverage.tests
     , Test.Example.Exception.tests
     , Test.Example.QuickCheck.tests

--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -55,6 +55,7 @@ library
     , concurrent-output               >= 1.7        && < 1.11
     , containers                      >= 0.4        && < 0.7
     , directory                       >= 1.2        && < 1.4
+    , erf                             >= 2.0        && < 2.1
     , exceptions                      >= 0.7        && < 0.11
     , fail                            >= 4.9        && < 5
     , lifted-async                    >= 0.7        && < 0.11
@@ -126,6 +127,7 @@ test-suite test
 
   other-modules:
     Test.Hedgehog.Applicative
+    Test.Hedgehog.Confidence
     Test.Hedgehog.Filter
     Test.Hedgehog.Seed
     Test.Hedgehog.Text

--- a/hedgehog/src/Hedgehog.hs
+++ b/hedgehog/src/Hedgehog.hs
@@ -66,6 +66,9 @@ module Hedgehog (
   , checkParallel
   , checkSequential
 
+  , Confidence
+  , withConfidence
+
   , withTests
   , TestLimit
 
@@ -167,6 +170,7 @@ import           Hedgehog.Internal.Property (forAll, forAllWith)
 import           Hedgehog.Internal.Property (LabelName, MonadTest(..))
 import           Hedgehog.Internal.Property (Property, PropertyT, PropertyName)
 import           Hedgehog.Internal.Property (Group(..), GroupName)
+import           Hedgehog.Internal.Property (Confidence, withConfidence)
 import           Hedgehog.Internal.Property (ShrinkLimit, withShrinks)
 import           Hedgehog.Internal.Property (ShrinkRetries, withRetries)
 import           Hedgehog.Internal.Property (Test, TestT, property, test)

--- a/hedgehog/src/Hedgehog.hs
+++ b/hedgehog/src/Hedgehog.hs
@@ -67,6 +67,7 @@ module Hedgehog (
   , checkSequential
 
   , Confidence
+  , terminateEarly
   , withConfidence
 
   , withTests
@@ -170,7 +171,7 @@ import           Hedgehog.Internal.Property (forAll, forAllWith)
 import           Hedgehog.Internal.Property (LabelName, MonadTest(..))
 import           Hedgehog.Internal.Property (Property, PropertyT, PropertyName)
 import           Hedgehog.Internal.Property (Group(..), GroupName)
-import           Hedgehog.Internal.Property (Confidence, withConfidence)
+import           Hedgehog.Internal.Property (Confidence, terminateEarly, withConfidence)
 import           Hedgehog.Internal.Property (ShrinkLimit, withShrinks)
 import           Hedgehog.Internal.Property (ShrinkRetries, withRetries)
 import           Hedgehog.Internal.Property (Test, TestT, property, test)

--- a/hedgehog/src/Hedgehog.hs
+++ b/hedgehog/src/Hedgehog.hs
@@ -67,7 +67,7 @@ module Hedgehog (
   , checkSequential
 
   , Confidence
-  , terminateEarly
+  , verifiedTermination
   , withConfidence
 
   , withTests
@@ -171,7 +171,7 @@ import           Hedgehog.Internal.Property (forAll, forAllWith)
 import           Hedgehog.Internal.Property (LabelName, MonadTest(..))
 import           Hedgehog.Internal.Property (Property, PropertyT, PropertyName)
 import           Hedgehog.Internal.Property (Group(..), GroupName)
-import           Hedgehog.Internal.Property (Confidence, terminateEarly, withConfidence)
+import           Hedgehog.Internal.Property (Confidence, verifiedTermination, withConfidence)
 import           Hedgehog.Internal.Property (ShrinkLimit, withShrinks)
 import           Hedgehog.Internal.Property (ShrinkRetries, withRetries)
 import           Hedgehog.Internal.Property (Test, TestT, property, test)

--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -1105,7 +1105,7 @@ wilson k n z =
 
 wilsonLowerBound :: Integer -> Integer -> Double -> Double
 wilsonLowerBound k n a =
-  wilson k n $ invnormcdf (a / 2)
+  wilson k n $ invnormcdf (1 - (1 - a / 2))
 
 wilsonUpperBound :: Integer -> Integer -> Double -> Double
 wilsonUpperBound k n a =

--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -1067,8 +1067,6 @@ coverageFailures tests (Coverage kvs) =
 confidenceSuccess :: TestCount -> Confidence -> Coverage CoverCount -> Bool
 confidenceSuccess tests confidence =
   let
-    -- FIXME this tolerance could be customizable in `Confidence`, barring
-    -- making the API less intuitive
     assertLow :: Label CoverCount -> Bool
     assertLow coverCount@MkLabel{..} =
       fst (boundsForLabel tests confidence coverCount)

--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -1064,13 +1064,16 @@ coverageFailures tests (Coverage kvs) =
 confidenceSuccess :: TestCount -> Confidence -> Coverage CoverCount -> Bool
 confidenceSuccess tests confidence =
   let
+    -- FIXME this tolerance could be customizable in `Confidence`, barring
+    -- making the API less intuitive
+    tolerance = 0.9
     assertLow :: Label CoverCount -> Bool
     assertLow MkLabel{..} =
       wilsonLowerBound
         (fromIntegral $ unCoverCount labelAnnotation)
         (fromIntegral tests)
         (1 / fromIntegral (unConfidence confidence))
-      >= 0.9 * (unCoverPercentage labelMinimum / 100.0)
+      >= tolerance * (unCoverPercentage labelMinimum / 100.0)
   in
     and . fmap assertLow . Map.elems . coverageLabels
 

--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -113,6 +113,8 @@ module Hedgehog.Internal.Property (
   , mkTestT
   , runTest
   , runTestT
+
+  , wilsonBounds
   ) where
 
 import           Control.Applicative (Alternative(..))
@@ -425,7 +427,7 @@ newtype CoverCount =
 newtype CoverPercentage =
   CoverPercentage {
       unCoverPercentage :: Double
-    } deriving (Eq, Ord, Show, Num)
+    } deriving (Eq, Ord, Show, Num, Fractional)
 
 -- | The name of a classifier.
 --
@@ -1067,12 +1069,10 @@ confidenceSuccess tests confidence =
   let
     -- FIXME this tolerance could be customizable in `Confidence`, barring
     -- making the API less intuitive
-    tolerance = 0.9
     assertLow :: Label CoverCount -> Bool
     assertLow coverCount@MkLabel{..} =
       fst (boundsForLabel tests confidence coverCount)
-      >=
-      tolerance * (unCoverPercentage labelMinimum / 100.0)
+        >= unCoverPercentage labelMinimum / 100.0
   in
     and . fmap assertLow . Map.elems . coverageLabels
 
@@ -1084,8 +1084,7 @@ confidenceFailure tests confidence =
     assertHigh :: Label CoverCount -> Bool
     assertHigh coverCount@MkLabel{..} =
       snd (boundsForLabel tests confidence coverCount)
-      <
-      (unCoverPercentage labelMinimum / 100.0)
+        < (unCoverPercentage labelMinimum / 100.0)
   in
     or . fmap assertHigh . Map.elems . coverageLabels
 

--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -12,6 +12,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -31,7 +32,6 @@ module Hedgehog.Internal.Property (
   , ShrinkLimit(..)
   , ShrinkCount(..)
   , ShrinkRetries(..)
-  , withConfidence
   , withTests
   , withDiscards
   , withShrinks
@@ -93,6 +93,12 @@ module Hedgehog.Internal.Property (
   , CoverPercentage(..)
   , toCoverCount
 
+  -- * Confidence
+  , Confidence(..)
+  , confidenceSuccess
+  , confidenceFailure
+  , withConfidence
+
   -- * Internal
   -- $internal
   , defaultConfig
@@ -142,6 +148,7 @@ import qualified Data.Char as Char
 import           Data.Functor.Identity (Identity(..))
 import           Data.Map (Map)
 import qualified Data.Map.Strict as Map
+import           Data.Number.Erf (invnormcdf)
 import qualified Data.List as List
 import           Data.Semigroup (Semigroup(..))
 import           Data.String (IsString)
@@ -228,7 +235,7 @@ newtype PropertyName =
 --   for 1 in 10^9 tests.
 newtype Confidence =
   Confidence {
-    unConfidence :: Int
+    unConfidence :: Integer
   } deriving (Eq, Ord, Show, Num, Lift)
 
 -- | Configuration for a property test.
@@ -919,6 +926,9 @@ mapConfig :: (PropertyConfig -> PropertyConfig) -> Property -> Property
 mapConfig f (Property cfg t) =
   Property (f cfg) t
 
+-- | Make sure that the result is statistically significant in accordance to
+--   the passed 'Confidence'
+--
 withConfidence :: Confidence -> Property -> Property
 withConfidence c =
   mapConfig $ \config -> config { propertyConfidence = Just c }
@@ -1037,6 +1047,58 @@ coverageSuccess tests =
 coverageFailures :: TestCount -> Coverage CoverCount -> [Label CoverCount]
 coverageFailures tests (Coverage kvs) =
   filter (not . labelCovered tests) (Map.elems kvs)
+
+-- | Is true when the test coverage satisfies the specified 'Confidence'
+--   contstraint for all 'Coverage CoverCount's
+confidenceSuccess :: TestCount -> Confidence -> Coverage CoverCount -> Bool
+confidenceSuccess tests confidence =
+  let
+    assertLow :: Label CoverCount -> Bool
+    assertLow MkLabel{..} =
+      wilsonLowerBound
+        (fromIntegral $ unCoverCount labelAnnotation)
+        (fromIntegral tests)
+        (1 / fromIntegral (unConfidence confidence))
+      >= 0.9 * (unCoverPercentage labelMinimum / 100.0)
+  in
+    and . fmap assertLow . Map.elems . coverageLabels
+
+-- | Is true when there exists a label that is sure to have failed according to
+--   the 'Confidence' constraint
+confidenceFailure :: TestCount -> Confidence -> Coverage CoverCount -> Bool
+confidenceFailure tests confidence =
+  let
+    assertHigh :: Label CoverCount -> Bool
+    assertHigh MkLabel{..} =
+      wilsonUpperBound
+        (fromIntegral $ unCoverCount labelAnnotation)
+        (fromIntegral tests)
+        (1 / fromIntegral (unConfidence confidence))
+      < (unCoverPercentage labelMinimum / 100.0)
+  in
+    or . fmap assertHigh . Map.elems . coverageLabels
+
+-- In order to get an accurate measurement with small sample sizes, we're
+-- using the Wilson score interval
+-- (<https://en.wikipedia.org/wiki/Binomial_proportion_confidence_interval#Wilson_score_interval
+-- wikipedia>) instead of a normal approximation interval.
+wilson :: Integer -> Integer -> Double -> Double
+wilson k n z =
+  let
+    nf = fromIntegral n
+    p = fromIntegral k / fromIntegral n
+  in
+    (p + z * z/(2 * nf) + z * sqrt (p * (1 - p) / nf + z * z / (4 * nf * nf)))
+    /
+    (1 + z * z / nf)
+
+wilsonLowerBound :: Integer -> Integer -> Double -> Double
+wilsonLowerBound k n a =
+  wilson k n $ invnormcdf (a / 2)
+
+wilsonUpperBound :: Integer -> Integer -> Double -> Double
+wilsonUpperBound k n a =
+  wilson k n $ invnormcdf (1 - a / 2)
 
 fromLabel :: Label a -> Coverage a
 fromLabel x =

--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -100,7 +100,7 @@ module Hedgehog.Internal.Property (
   , confidenceSuccess
   , confidenceFailure
   , withConfidence
-  , terminateEarly
+  , verifiedTermination
   , defaultConfidence
 
   -- * Internal
@@ -964,8 +964,8 @@ withConfidence c =
             setConfidence propertyTerminationCriteria
         }
 
-terminateEarly :: Property -> Property
-terminateEarly =
+verifiedTermination :: Property -> Property
+verifiedTermination =
   mapConfig $ \config@PropertyConfig{..} ->
     let
       newTerminationCriteria = case propertyTerminationCriteria of

--- a/hedgehog/src/Hedgehog/Internal/Runner.hs
+++ b/hedgehog/src/Hedgehog/Internal/Runner.hs
@@ -167,16 +167,18 @@ checkReport cfg size0 seed0 test0 updateUI =
       propertyConfidence cfg
 
     successVerified count coverage =
-      count > 0 &&
+      count `mod` 100 == 0 &&
       -- If the user wants a statistically significant result, this function
       -- will run a confidence check. Otherwise, it will default to checking
       -- the percentage of encountered labels
       maybe False (\c -> confidenceSuccess count c coverage) confidence
 
     failureVerified count coverage =
-      count > 0 &&
       -- Will be true if we can statistically verify that our coverage was
-      -- inadequate
+      -- inadequate.
+      -- Testing only on 100s to minimise repeated measurement statistical
+      -- errors.
+      count `mod` 100 == 0 &&
       maybe False (\c -> confidenceFailure count c coverage) confidence
 
     loop ::
@@ -198,7 +200,7 @@ checkReport cfg size0 seed0 test0 updateUI =
           successVerified tests coverage0
         enoughTestsRun =
           tests >= fromIntegral (fromMaybe defaultMinTests testLimit) &&
-          (isNothing (propertyConfidence cfg) || hasReachedCoverage)
+            (isNothing (propertyConfidence cfg) || hasReachedCoverage)
 
       if size > 99 then
         -- size has reached limit, reset to 0
@@ -217,7 +219,7 @@ checkReport cfg size0 seed0 test0 updateUI =
             0
             (Just coverage0)
             Nothing
-            "Test coverage cannot be reached, aborted"
+            ("Test coverage cannot be reached after " <> show tests <> " tests")
             Nothing
             []
 

--- a/hedgehog/src/Hedgehog/Internal/Runner.hs
+++ b/hedgehog/src/Hedgehog/Internal/Runner.hs
@@ -191,6 +191,19 @@ checkReport cfg size0 seed0 test0 updateUI =
         -- size has reached limit, reset to 0
         loop tests discards 0 seed coverage0
 
+      else if failureVerified tests coverage0 then
+        -- tests have been verified to not reach coverage for at least one label
+        pure . Report tests discards coverage0 . Failed $
+          mkFailure
+            size
+            seed
+            0
+            (Just coverage0)
+            Nothing
+            "Test coverage cannot be reached, aborted"
+            Nothing
+            []
+
       else if tests >= fromIntegral (propertyTestLimit cfg) then
         -- we've hit the test limit
         if successVerified tests coverage0 then
@@ -207,10 +220,7 @@ checkReport cfg size0 seed0 test0 updateUI =
               0
               (Just coverage0)
               Nothing
-              (if failureVerified tests coverage0 then
-                "Could not meet confidence criteria."
-              else
-                "Insufficient coverage.")
+              "Insufficient coverage."
               Nothing
               []
 

--- a/hedgehog/src/Hedgehog/Internal/Runner.hs
+++ b/hedgehog/src/Hedgehog/Internal/Runner.hs
@@ -168,9 +168,7 @@ checkReport cfg size0 seed0 test0 updateUI =
       -- If the user wants a statistically significant result, this function
       -- will run a confidence check. Otherwise, it will default to checking
       -- the percentage of encountered labels
-      maybe
-        (coverageSuccess count coverage)
-        (\c -> confidenceSuccess count c coverage) confidence
+      maybe False (\c -> confidenceSuccess count c coverage) confidence
 
     failureVerified count coverage =
       -- Will be true if we can statistically verify that our coverage was
@@ -191,6 +189,10 @@ checkReport cfg size0 seed0 test0 updateUI =
         -- size has reached limit, reset to 0
         loop tests discards 0 seed coverage0
 
+      else if tests > 0 && successVerified tests coverage0 then
+        -- tests have been verified to reach coverage for all labels
+        pure $ Report tests discards coverage0 OK
+
       else if failureVerified tests coverage0 then
         -- tests have been verified to not reach coverage for at least one label
         pure . Report tests discards coverage0 . Failed $
@@ -206,7 +208,7 @@ checkReport cfg size0 seed0 test0 updateUI =
 
       else if tests >= fromIntegral (propertyTestLimit cfg) then
         -- we've hit the test limit
-        if successVerified tests coverage0 then
+        if coverageSuccess tests coverage0 then
           -- all classifiers satisfied, test was successful
           pure $ Report tests discards coverage0 OK
 

--- a/hedgehog/test/Test/Hedgehog/Confidence.hs
+++ b/hedgehog/test/Test/Hedgehog/Confidence.hs
@@ -6,16 +6,19 @@ import           Hedgehog
 import qualified Hedgehog.Range as Range
 import qualified Hedgehog.Internal.Gen as Gen
 
+confidence :: Confidence
+confidence = 10 ^ (9 :: Int)
+
 prop_with_confidence :: Property
 prop_with_confidence =
-  withConfidence (10^9) . property $ do
+  verifiedTermination . withConfidence confidence . property $ do
     number <- forAll (Gen.int $ Range.linear 1 10)
-    cover 30 "number == 1" $ number == 1
+    cover 20 "number == 1" $ number == 1
 
 -- This tests that at least 1000 tests are run for the property
 prop_with_confidence_and_min_tests :: Property
 prop_with_confidence_and_min_tests =
-  withConfidence (10^9) . withTests 1000 . property $ do
+  withConfidence confidence . withTests 1000 . property $ do
     number <- forAll (Gen.int $ Range.linear 1 10)
     cover 10 "number == 2" $ number == 2
 

--- a/hedgehog/test/Test/Hedgehog/Confidence.hs
+++ b/hedgehog/test/Test/Hedgehog/Confidence.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Test.Hedgehog.Confidence where
+
+import           Hedgehog
+import qualified Hedgehog.Range as Range
+import qualified Hedgehog.Internal.Gen as Gen
+
+prop_with_confidence :: Property
+prop_with_confidence =
+  withConfidence (10^9) . withTests 10000 . property $ do
+    number <- forAll (Gen.int $ Range.linear 1 10)
+    cover 30 "number == 1" $ number == 1
+
+tests :: IO Bool
+tests =
+  checkParallel $$(discover)

--- a/hedgehog/test/Test/Hedgehog/Confidence.hs
+++ b/hedgehog/test/Test/Hedgehog/Confidence.hs
@@ -8,9 +8,16 @@ import qualified Hedgehog.Internal.Gen as Gen
 
 prop_with_confidence :: Property
 prop_with_confidence =
-  withConfidence (10^9) . withTests 10000 . property $ do
+  withConfidence (10^9) . property $ do
     number <- forAll (Gen.int $ Range.linear 1 10)
     cover 30 "number == 1" $ number == 1
+
+-- This tests that at least 1000 tests are run for the property
+prop_with_confidence_and_min_tests :: Property
+prop_with_confidence_and_min_tests =
+  withConfidence (10^9) . withTests 1000 . property $ do
+    number <- forAll (Gen.int $ Range.linear 1 10)
+    cover 10 "number == 2" $ number == 2
 
 tests :: IO Bool
 tests =

--- a/hedgehog/test/test.hs
+++ b/hedgehog/test/test.hs
@@ -1,6 +1,7 @@
 import           Hedgehog.Main (defaultMain)
 
 import qualified Test.Hedgehog.Applicative
+import qualified Test.Hedgehog.Confidence
 import qualified Test.Hedgehog.Filter
 import qualified Test.Hedgehog.Seed
 import qualified Test.Hedgehog.Text
@@ -11,6 +12,7 @@ main :: IO ()
 main =
   defaultMain [
       Test.Hedgehog.Applicative.tests
+    , Test.Hedgehog.Confidence.tests
     , Test.Hedgehog.Filter.tests
     , Test.Hedgehog.Seed.tests
     , Test.Hedgehog.Text.tests


### PR DESCRIPTION
This PR adds ability to be able to statistically verify that a result is correct. It does not _yet_ add the ability to cancel running tests if they can never reach the specified coverage.