### PR TITLE
Add histograms to labels / coverage

### DIFF
--- a/hedgehog-example/src/Test/Example/Coverage.hs
+++ b/hedgehog-example/src/Test/Example/Coverage.hs
@@ -6,8 +6,7 @@ module Test.Example.Coverage (
   ) where
 
 import           Control.Concurrent (threadDelay)
-
-import           Data.Foldable (for_)
+import           Control.Monad (when)
 
 import           Hedgehog
 import qualified Hedgehog.Gen as Gen
@@ -28,20 +27,46 @@ data Bucket =
   Bucket !Int
   deriving (Eq, Show)
 
+-- Good for testing progress bar boundary conditions.
+prop_occupy :: Property
+prop_occupy =
+  property $ do
+    size <- forAll $ Gen.sized pure
+    if size == 1 then
+      label "wall st"
+    else
+      label "occupy"
+
+-- Good for testing progress bar boundary conditions.
+prop_world_cup_titles_2018 :: Property
+prop_world_cup_titles_2018 =
+  withTests 5 . property $ do
+    size <- forAll $ Gen.sized pure
+    flip classify (size < 5) "brazil"
+    flip classify (size < 4) "italy"
+    flip classify (size < 4) "germany"
+    flip classify (size < 2) "uruguay"
+    flip classify (size < 2) "france"
+    flip classify (size < 2) "argentina"
+    flip classify (size < 1) "spain"
+    flip classify (size < 1) "england"
+    flip classify (size < 0) "australia"
+    flip classify (size < 0) "greece"
+
 prop_collect :: Property
 prop_collect =
   withTests 101 . property $ do
     x <- forAll .
-      fmap Bucket . Gen.int $ Range.linear 1 10
+      fmap Bucket . Gen.int $ Range.linear 1 9
     evalIO $ threadDelay 10000
     collect x
 
 prop_classify :: Property
 prop_classify =
-  withTests 1 . property $ do
-    for_ [1 :: Int ..100] $ \a -> do
-      classify "small number" $ a < 50
-      classify "big number" $ a >= 50
+  withTests 100 . property $ do
+    a <- forAll $ Gen.int (Range.constant 0 100)
+    classify "small number" $ a < 50
+    classify "big number" $ a >= 50
 
 prop_cover_number :: Property
 prop_cover_number =
@@ -51,6 +76,7 @@ prop_cover_number =
     cover 50 "small number" $ number < 10
     cover 15 "medium number" $ number >= 20
     cover 5 "big number" $ number >= 70
+    when (number > 10) $ label ">10 number"
 
 prop_cover_bool :: Property
 prop_cover_bool =


### PR DESCRIPTION
This PR adds unicode histograms / percentage bars to the new labelling / coverage system. Not sure if I have quite the right balance yet, but time will tell.

<img width="339" src="https://user-images.githubusercontent.com/134805/57575278-09c13580-747a-11e9-91ae-efba129c79ae.png">

For labels with coverage requirements, the minimum required coverage is shown on the right hand side of the histogram, along with a tick or a cross indicating whether we met the requirement. We also highlight visually (with red dots) the additional coverage required to make it to the requirement, not sure if I like this yet but we'll give it go.

Shame :australia: :greece: haven't won any world cups :cry: 