### PR TITLE
Fixups after previewing the package candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - `diff` function which takes any `a -> a -> Bool` comparison function ([#196][196], [@chessai][chessai] / [@jacobstanley][jacobstanley])
 - Labelling of test runs via `label`, `collect` ([#262][262], [@ruhatch][ruhatch] / [@jacobstanley][jacobstanley])
 - Classification of test runs via `cover`, `classify` ([#253][253], [@felixmulder][felixmulder] / [@jacobstanley][jacobstanley])
-- Define proper `Applicative` instances for `NodeT`, `TreeT` and `GenT` ([#173][173][@sjakobi][sjakobi]
+- Define proper `Applicative` instances for `NodeT`, `TreeT` and `GenT` ([#173][173][@sjakobi][sjakobi])
 - `MonadFail` instance for `PropertyT` ([#267][267], [@geigerzaehler][geigerzaehler])
 - `MonadResource` instance for `PropertyT` ([#268][268], [@geigerzaehler][geigerzaehler])
 - Example for the `tripping` function ([#258][258], [@HuwCampbell][HuwCampbell])
@@ -141,6 +141,8 @@
   https://github.com/sjakobi
 [felixmulder]:
   https://github.com/felixmulder
+[chessai]:
+  https://github.com/chessai
 [edsko]:
   https://github.com/edsko
 
@@ -152,6 +154,8 @@
   https://github.com/hedgehogqa/haskell-hedgehog/pull/272
 [268]:
   https://github.com/hedgehogqa/haskell-hedgehog/pull/268
+[267]:
+  https://github.com/hedgehogqa/haskell-hedgehog/pull/267
 [262]:
   https://github.com/hedgehogqa/haskell-hedgehog/pull/262
 [258]:
@@ -174,10 +178,14 @@
   https://github.com/hedgehogqa/haskell-hedgehog/pull/202
 [198]:
   https://github.com/hedgehogqa/haskell-hedgehog/pull/198
+[196]:
+  https://github.com/hedgehogqa/haskell-hedgehog/pull/196
 [185]:
   https://github.com/hedgehogqa/haskell-hedgehog/pull/185
 [184]:
   https://github.com/hedgehogqa/haskell-hedgehog/pull/184
+[173]:
+  https://github.com/hedgehogqa/haskell-hedgehog/pull/173
 [168]:
   https://github.com/hedgehogqa/haskell-hedgehog/pull/168
 [162]:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-<!-- horrendous hacks, this tag is never closed :maniacal_laughing: -->
+<!--
+Apologies to those who are able to read this. Unfortunately, Hackage
+doesn't seem to render the HTML portion of the markdown spec so you may
+be better off paying us a visit on GitHub instead:
+https://github.com/hedgehogqa/haskell-hedgehog
+-->
+
 <div align="center">
 
 <img width="400" src="https://github.com/hedgehogqa/haskell-hedgehog/raw/master/img/hedgehog-text-logo.png" />
@@ -7,12 +13,11 @@
 
 [![Hackage][hackage-shield]][hackage] [![Travis][travis-shield]][travis] [![AppVeyor][appveyor-shield]][appveyor]
 
-<!-- this one isn't either! :D -->
 <div align="left">
 
-<!-- end of horrendous hacks, or is it? -->
+[Hedgehog](http://hedgehog.qa/) automatically generates a comprehensive array of test cases, exercising your software in ways human testers would never imagine.
 
-[Hedgehog](http://hedgehog.qa/) automatically generates a comprehensive array of test cases, exercising your software in ways human testers would never imagine. Generate hundreds of test cases automatically, exposing even the most insidious of corner cases. Failures are automatically simplified, giving developers coherent, intelligible error messages.
+Generate hundreds of test cases automatically, exposing even the most insidious of corner cases. Failures are automatically simplified, giving developers coherent, intelligible error messages.
 
 ## Features
 
@@ -82,7 +87,6 @@ You can then load the module in GHCi, and run it:
 
 ```
 
-<!-- more horendous hacks :) -->
 <div align="center">
 <br />
 <img width="307" src="https://github.com/hedgehogqa/haskell-hedgehog/raw/master/img/hedgehog-logo-grey.png" />

--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -11,14 +11,17 @@ homepage:
 bug-reports:
   https://github.com/hedgehogqa/haskell-hedgehog/issues
 synopsis:
-  Hedgehog will eat all your bugs.
+  Release with confidence.
 description:
-  Hedgehog is a modern property-based testing system, in the spirit of
-  QuickCheck. Hedgehog uses integrated shrinking, so shrinks obey the
-  invariants of generated values by construction.
+  <http://hedgehog.qa/ Hedgehog> automatically generates a comprehensive array
+  of test cases, exercising your software in ways human testers would never
+  imagine.
   .
-  To get started quickly, see the examples:
-  <https://github.com/hedgehogqa/haskell-hedgehog/tree/master/hedgehog-example>
+  Generate hundreds of test cases automatically, exposing even the
+  most insidious of corner cases. Failures are automatically simplified, giving
+  developers coherent, intelligible error messages.
+  .
+  To get started quickly, see the <https://github.com/hedgehogqa/haskell-hedgehog/tree/master/hedgehog-example examples>.
 category:
   Testing
 license:


### PR DESCRIPTION
Should have really done that earlier :D

The `CHANGELOG.md` fixups didn't make it to the hackage release unfortunately, will have to wait until next time. Shame the changelog can't be modified after the fact like version bounds. Maybe via `Upload Documentation` idk.