### PR TITLE
Add basic symbol rendering for non-Unicode terminals

### DIFF
--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -638,21 +638,21 @@ failDiff x y =
         failWith Nothing $
         unlines $ [
             "Failed"
-          , "━━ lhs ━━"
+          , unicode "━━ lhs ━━" "-- lhs --"
           , showPretty x
-          , "━━ rhs ━━"
+          , unicode "━━ rhs ━━" "-- lhs --"
           , showPretty y
           ]
 
     Just vdiff@(ValueSame _) ->
       withFrozenCallStack $
         failWith (Just $
-          Diff "━━━ Failed ("  "" "no differences" "" ") ━━━" vdiff) ""
+          Diff (unicode "━━━ Failed (" "=== Failed (")  "" "no differences" "" (unicode ") ━━━" ") ===") vdiff) ""
 
     Just vdiff ->
       withFrozenCallStack $
         failWith (Just $
-          Diff "━━━ Failed (" "- lhs" ") (" "+ rhs" ") ━━━" vdiff) ""
+          Diff (unicode "━━━ Failed (" "=== Failed (") "- lhs" ") (" "+ rhs" (unicode ") ━━━" ") ===") vdiff) ""
 
 -- | Fails with an error which renders the type of an exception and its error
 --   message.
@@ -661,7 +661,7 @@ failException :: (MonadTest m, HasCallStack) => SomeException -> m a
 failException (SomeException x) =
   withFrozenCallStack $
     failWith Nothing $ unlines [
-        "━━━ Exception (" ++ show (typeOf x) ++ ") ━━━"
+        unicode "━━━ Exception (" "=== Exception (" ++ show (typeOf x) ++ unicode ") ━━━" ") ==="
       , List.dropWhileEnd Char.isSpace (displayException x)
       ]
 

--- a/hedgehog/src/Hedgehog/Internal/Report.hs
+++ b/hedgehog/src/Hedgehog/Internal/Report.hs
@@ -430,7 +430,7 @@ ppFailedInputDeclaration (FailedAnnotation msloc val) =
     let
       ppValLine =
         WL.indent startCol .
-          (markup AnnotationGutter (WL.text "│ ") <>) .
+          (markup AnnotationGutter (WL.text $ unicode "│ " "| ") <>) .
           markup AnnotationValue .
           WL.text
 
@@ -507,7 +507,7 @@ ppFailureLocation msgs mdiff sloc =
 
       ppFailure x =
         WL.indent startCol $
-          markup FailureGutter (WL.text "│ ") <> x
+          markup FailureGutter (WL.text $ unicode "│ " "| ") <> x
 
       msgDocs =
         fmap ((StyleFailure, ) . ppFailure . markup FailureMessage) msgs
@@ -546,9 +546,9 @@ ppDeclaration decl =
       let
         ppLocation =
           WL.indent (digits + 1) $
-            markup (StyledBorder StyleDefault) "┏━━" <+>
+            markup (StyledBorder StyleDefault) (unicode "┏━━" ",--") <+>
             markup DeclarationLocation (WL.text (declarationFile decl)) <+>
-            markup (StyledBorder StyleDefault) "━━━"
+            markup (StyledBorder StyleDefault) (unicode "━━━" "---")
 
         digits =
           length . show . unLineNo $ lineNumber lastLine
@@ -561,12 +561,12 @@ ppDeclaration decl =
 
         ppSource style n src =
           markup (StyledLineNo style) (ppLineNo n) <+>
-          markup (StyledBorder style) "┃" <+>
+          markup (StyledBorder style) (unicode "┃" "|") <+>
           markup (StyledSource style) (WL.text src)
 
         ppAnnot (style, doc) =
           markup (StyledLineNo style) ppEmptyNo <+>
-          markup (StyledBorder style) "┃" <+>
+          markup (StyledBorder style) (unicode "┃" "|") <+>
           doc
 
         ppLines = do
@@ -702,7 +702,7 @@ ppProgress name (Report tests discards coverage status) =
   case status of
     Running ->
       pure . WL.vsep $ [
-          icon RunningIcon '●' . WL.annotate RunningHeader $
+          icon RunningIcon (unicode '●' '>') . WL.annotate RunningHeader $
             ppName name <+>
             "passed" <+>
             ppTestCount tests <>
@@ -712,7 +712,7 @@ ppProgress name (Report tests discards coverage status) =
         ppCoverage tests coverage
 
     Shrinking failure ->
-      pure . icon ShrinkingIcon '↯' . WL.annotate ShrinkingHeader $
+      pure . icon ShrinkingIcon (unicode '↯' '%') . WL.annotate ShrinkingHeader $
         ppName name <+>
         "failed after" <+>
         ppTestCount tests <>
@@ -725,7 +725,7 @@ ppResult name (Report tests discards coverage result) = do
     Failed failure -> do
       pfailure <- ppFailureReport name tests failure
       pure . WL.vsep $ [
-          icon FailedIcon '✗' . WL.annotate FailedText $
+          icon FailedIcon (unicode '✗' 'X') . WL.annotate FailedText $
             ppName name <+>
             "failed after" <+>
             ppTestCount tests <>
@@ -737,7 +737,7 @@ ppResult name (Report tests discards coverage result) = do
 
     GaveUp ->
       pure . WL.vsep $ [
-          icon GaveUpIcon '⚐' . WL.annotate GaveUpText $
+          icon GaveUpIcon (unicode '⚐' '?') . WL.annotate GaveUpText $
             ppName name <+>
             "gave up after" <+>
             ppDiscardCount discards <>
@@ -749,7 +749,7 @@ ppResult name (Report tests discards coverage result) = do
 
     OK ->
       pure . WL.vsep $ [
-          icon SuccessIcon '✓' . WL.annotate SuccessText $
+          icon SuccessIcon (unicode '✓' '~') . WL.annotate SuccessText $
             ppName name <+>
             "passed" <+>
             ppTestCount tests <>
@@ -851,7 +851,7 @@ ppLabel tests w x@(MkLabel name _ minimum_ count) =
 
     licon =
       if not covered then
-        WL.annotate CoverageText "⚠ "
+        WL.annotate CoverageText $ unicode "⚠ " "! "
       else
         "  "
 
@@ -871,11 +871,11 @@ ppLabel tests w x@(MkLabel name _ minimum_ count) =
       if widthMinimum w == 0 then
         mempty
       else if not covered then
-        " ✗ " <> wminimum
+        unicode " ✗ " " X " <> wminimum
       else if minimum_ == 0 then
         "   " <> ppLeftPad (widthMinimum w) ""
       else
-        " ✓ " <> wminimum
+        unicode " ✓ " " ~ " <> wminimum
 
     lcover =
       if widthMinimum w == 0 then
@@ -894,7 +894,7 @@ ppLabel tests w x@(MkLabel name _ minimum_ count) =
       , ltext lcover
       , lborder " "
       , ltext $ ppCoverBar (coverPercentage tests count) minimum_
-      , lborder "" -- "│"
+      , lborder "" -- unicode "│" "|"
       , ltext lminimum
       ]
 
@@ -982,16 +982,16 @@ ppCoverBar (CoverPercentage percentage) (CoverPercentage minimum_) =
       --     ++ " " ++ show fillWidth
       ]
   in
-    bar ('█', ['·', '▏', '▎', '▍', '▌', '▋', '▊', '▉'])
+    bar $ unicode ('█', "·▏▎▍▌▋▊▉") ('@', ".:-=+*#%")
 
     -- FIXME Maybe this should be configurable?
     -- Alternative histogram bars:
-    --bar ('⣿', ['·', '⡀', '⡄', '⡆', '⡇', '⣇', '⣧', '⣷'])
-    --bar ('⣿', ['⢕', '⡀', '⣀', '⣄', '⣤', '⣦', '⣶', '⣷'])
-    --bar ('⣿', ['⢕', '⡵', '⢗', '⣗', '⣟'])
-    --bar ('⣿', [' ', '⡵', '⢗', '⣗', '⣟'])
-    --bar ('█', ['░','▓'])
-    --bar ('█', ['░'])
+    --bar $ unicode ('⣿', "·⡀⡄⡆⡇⣇⣧⣷") _
+    --bar $ unicode ('⣿', "⢕⡀⣀⣄⣤⣦⣶⣷") _
+    --bar $ unicode ('⣿', "⢕⡵⢗⣗⣟") _
+    --bar $ unicode ('⣿', " ⡵⢗⣗⣟") _
+    --bar $ unicode ('█', "░▓") _
+    --bar $ unicode ('█', "░") _
 
 renderCoverPercentage :: CoverPercentage -> String
 renderCoverPercentage (CoverPercentage percentage) =
@@ -1007,13 +1007,13 @@ ppWhenNonZero suffix n =
 annotateSummary :: Summary -> Doc Markup -> Doc Markup
 annotateSummary summary =
   if summaryFailed summary > 0 then
-    icon FailedIcon '✗' . WL.annotate FailedText
+    icon FailedIcon (unicode '✗' 'X') . WL.annotate FailedText
   else if summaryGaveUp summary > 0 then
-    icon GaveUpIcon '⚐' . WL.annotate GaveUpText
+    icon GaveUpIcon (unicode '⚐' '?') . WL.annotate GaveUpText
   else if summaryWaiting summary > 0 || summaryRunning summary > 0 then
-    icon WaitingIcon '○' . WL.annotate WaitingHeader
+    icon WaitingIcon (unicode '○' '.') . WL.annotate WaitingHeader
   else
-    icon SuccessIcon '✓' . WL.annotate SuccessText
+    icon SuccessIcon (unicode '✓' '~') . WL.annotate SuccessText
 
 ppSummary :: MonadIO m => Summary -> m (Doc Markup)
 ppSummary summary =

--- a/hedgehog/src/Hedgehog/Internal/Runner.hs
+++ b/hedgehog/src/Hedgehog/Internal/Runner.hs
@@ -46,6 +46,7 @@ import           Hedgehog.Internal.Region
 import           Hedgehog.Internal.Report
 import           Hedgehog.Internal.Seed (Seed)
 import qualified Hedgehog.Internal.Seed as Seed
+import           Hedgehog.Internal.Show (unicode)
 import           Hedgehog.Internal.Tree (TreeT(..), NodeT(..))
 import           Hedgehog.Range (Size)
 
@@ -304,7 +305,7 @@ checkGroup config (Group group props) =
     hSetEncoding stderr utf8
 #endif
 
-    putStrLn $ "━━━ " ++ unGroupName group ++ " ━━━"
+    putStrLn $ unicode "━━━ " "=== " ++ unGroupName group ++ unicode " ━━━" " ==="
 
     verbosity <- resolveVerbosity (runnerVerbosity config)
     summary <- checkGroupWith n verbosity (runnerColor config) props

--- a/hedgehog/src/Hedgehog/Internal/Show.hs
+++ b/hedgehog/src/Hedgehog/Internal/Show.hs
@@ -20,11 +20,15 @@ module Hedgehog.Internal.Show (
 
   , takeLeft
   , takeRight
+
+  , unicode
   ) where
 
 import           Data.Bifunctor (second)
 
 import           Text.Show.Pretty (Value(..), Name, reify, valToStr, ppShow)
+
+import           System.IO (localeEncoding, utf8, utf8_bom, utf16, utf16le, utf16be, utf32, utf32le, utf32be)
 
 
 data ValueDiff =
@@ -273,3 +277,10 @@ removed indent =
 added :: Int -> String -> [DocDiff]
 added indent =
   fmap (DocAdded indent) . lines
+
+unicode :: a -> a -> a
+unicode unicodeStr asciiStr =
+  if show localeEncoding `elem` map show [utf8, utf8_bom, utf16, utf16le, utf16be, utf32, utf32le, utf32be] then
+    unicodeStr
+  else
+    asciiStr

--- a/hedgehog/src/Hedgehog/Internal/State.hs
+++ b/hedgehog/src/Hedgehog/Internal/State.hs
@@ -78,7 +78,7 @@ import           Hedgehog.Internal.HTraversable (HTraversable(..))
 import           Hedgehog.Internal.Opaque (Opaque(..))
 import           Hedgehog.Internal.Property (MonadTest(..), Test, evalEither, evalM, success, runTest, failWith, annotate)
 import           Hedgehog.Internal.Range (Range)
-import           Hedgehog.Internal.Show (showPretty)
+import           Hedgehog.Internal.Show (showPretty, unicode)
 import           Hedgehog.Internal.Source (HasCallStack, withFrozenCallStack)
 
 
@@ -667,11 +667,11 @@ instance Show (Parallel m state) where
 renderParallel :: (Action m state -> [String]) -> Parallel m state -> String
 renderParallel render (Parallel pre xs ys) =
   unlines $ concat [
-      ["━━━ Prefix ━━━"]
+      [unicode "━━━ Prefix ━━━" "=== Prefix ==="]
     , concatMap render pre
-    , ["", "━━━ Branch 1 ━━━"]
+    , ["", unicode "━━━ Branch 1 ━━━" "=== Branch 1 ==="]
     , concatMap render xs
-    , ["", "━━━ Branch 2 ━━━"]
+    , ["", unicode "━━━ Branch 2 ━━━" "=== Branch 2 ==="]
     , concatMap render ys
     ]
 

--- a/hedgehog/src/Hedgehog/Internal/Tree.hs
+++ b/hedgehog/src/Hedgehog/Internal/Tree.hs
@@ -66,6 +66,7 @@ import           Data.Functor.Classes (showsUnaryWith, showsBinaryWith)
 import qualified Data.Maybe as Maybe
 
 import           Hedgehog.Internal.Distributive
+import           Hedgehog.Internal.Show
 
 import           Prelude hiding (filter)
 
@@ -642,13 +643,13 @@ renderForestLines xs0 =
       [x] -> do
         s <- renderTreeTLines x
         pure $
-          shift " └╼" "   " s
+          shift (unicode " └╼" " `-") "   " s
 
       x : xs -> do
         s <- renderTreeTLines x
         ss <- renderForestLines xs
         pure $
-          shift " ├╼" " │ " s ++ ss
+          shift (unicode " ├╼" " +-") (unicode " │ " " | ") s ++ ss
 
 -- | Render a tree of strings.
 --

--- a/hedgehog/src/Hedgehog/Internal/Tripping.hs
+++ b/hedgehog/src/Hedgehog/Internal/Tripping.hs
@@ -4,7 +4,7 @@ module Hedgehog.Internal.Tripping (
   ) where
 
 import           Hedgehog.Internal.Property (MonadTest, Diff(..), success, failWith)
-import           Hedgehog.Internal.Show (valueDiff, mkValue, showPretty)
+import           Hedgehog.Internal.Show (valueDiff, mkValue, showPretty, unicode)
 import           Hedgehog.Internal.Source (HasCallStack, withFrozenCallStack)
 
 
@@ -45,11 +45,11 @@ tripping x encode decode =
         Nothing ->
           withFrozenCallStack $
             failWith Nothing $ unlines [
-                "━━━ Original ━━━"
+                unicode "━━━ Original ━━━" "=== Original ==="
               , showPretty mx
-              , "━━━ Intermediate ━━━"
+              , unicode "━━━ Intermediate ━━━" "=== Intermediate ==="
               , showPretty i
-              , "━━━ Roundtrip ━━━"
+              , unicode "━━━ Roundtrip ━━━" "=== Roundtrip ==="
               , showPretty my
               ]
 
@@ -57,8 +57,8 @@ tripping x encode decode =
           withFrozenCallStack $
             failWith
               (Just $
-                Diff "━━━ " "- Original" ") (" "+ Roundtrip" " ━━━" diff) $
+                Diff (unicode "━━━ " "=== ") "- Original" ") (" "+ Roundtrip" (unicode " ━━━" " ===") diff) $
               unlines [
-                  "━━━ Intermediate ━━━"
+                  unicode "━━━ Intermediate ━━━" "=== Intermediate ==="
                 , showPretty i
                 ]


### PR DESCRIPTION
The [Windows Unicode workaround](https://github.com/hedgehogqa/haskell-hedgehog/blob/bfd9b93e328104e6273b5b1bd427c2789b769cfd/hedgehog/src/Hedgehog/Internal/Report.hs#L1171-L1175) is certainly valid for that platform, but it doesn't apply everywhere; case in point, Hedgehog crashes on my standard terminal (raw Linux tty) with the infamous `commitBuffer: invalid argument (invalid character)` message, since I keep it on a Latin-1 encoding for font support.  This fixes that for any ASCII-compatible encoding.

I'm not entirely happy with some of the symbols (there's *no* way to get a good checkmark in ASCII), and am completely happy to change any of my reassignments, but the test suite output looks about as good as I'm expecting it to.  There's still some notable text that doesn't get shown there (eg. [`Tree`](hedgehog/src/Hedgehog/Internal/Tree.hs) and [`Tripping`](hedgehog/src/Hedgehog/Internal/Tripping.hs)) so I'm not completely sure those fit in with everything else, though; they should -- they use the same design language -- but I can't guarantee it.

EDIT: One last thing I should mention: this doesn't update if the locale is changed after the test runner is started.  I don't see that as a large failing in as short-lived an application as they tend to be, and not worrying about it allows `unicode` to be used outside `MonadIO` which *is* a notable help.