### PR TITLE
Added a SizeLimit configuration option

### DIFF
--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -1,4 +1,4 @@
-version: 1.0
+version: 1.0.1
 
 name:
   hedgehog

--- a/hedgehog/src/Hedgehog.hs
+++ b/hedgehog/src/Hedgehog.hs
@@ -75,6 +75,9 @@ module Hedgehog (
   , withShrinks
   , ShrinkLimit
 
+  , withSize
+  , SizeLimit
+
   , withRetries
   , ShrinkRetries
 
@@ -168,6 +171,7 @@ import           Hedgehog.Internal.Property (LabelName, MonadTest(..))
 import           Hedgehog.Internal.Property (Property, PropertyT, PropertyName)
 import           Hedgehog.Internal.Property (Group(..), GroupName)
 import           Hedgehog.Internal.Property (ShrinkLimit, withShrinks)
+import           Hedgehog.Internal.Property (SizeLimit, withSize)
 import           Hedgehog.Internal.Property (ShrinkRetries, withRetries)
 import           Hedgehog.Internal.Property (Test, TestT, property, test)
 import           Hedgehog.Internal.Property (TestLimit, withTests)

--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -139,7 +139,6 @@ import qualified Control.Monad.Trans.State.Strict as Strict
 import qualified Control.Monad.Trans.Writer.Lazy as Lazy
 import qualified Control.Monad.Trans.Writer.Strict as Strict
 
-import           Data.Int (Int64)
 import qualified Data.Char as Char
 import           Data.Functor.Identity (Identity(..))
 import           Data.Map (Map)
@@ -245,13 +244,13 @@ data PropertyConfig =
 -- @
 --
 newtype TestLimit =
-  TestLimit Int64
+  TestLimit Int
   deriving (Eq, Ord, Show, Num, Enum, Real, Integral, Lift)
 
 -- | The number of tests a property ran successfully.
 --
 newtype TestCount =
-  TestCount Int64
+  TestCount Int
   deriving (Eq, Ord, Show, Num, Enum, Real, Integral)
 
 -- | The number of tests a property had to discard.
@@ -270,7 +269,7 @@ newtype DiscardCount =
 --
 --
 newtype DiscardLimit =
-  DiscardLimit Int64
+  DiscardLimit Int
   deriving (Eq, Ord, Show, Num, Enum, Real, Integral, Lift)
 
 -- | The number of shrinks to try before giving up on shrinking.
@@ -282,13 +281,13 @@ newtype DiscardLimit =
 -- @
 --
 newtype ShrinkLimit =
-  ShrinkLimit Int64
+  ShrinkLimit Int
   deriving (Eq, Ord, Show, Num, Enum, Real, Integral, Lift)
 
 -- | The numbers of times a property was able to shrink after a failing test.
 --
 newtype ShrinkCount =
-  ShrinkCount Int64
+  ShrinkCount Int
   deriving (Eq, Ord, Show, Num, Enum, Real, Integral)
 
 -- | The number of times to re-run a test during shrinking. This is useful if
@@ -307,7 +306,7 @@ newtype ShrinkCount =
 -- @
 --
 newtype ShrinkRetries =
-  ShrinkRetries Int64
+  ShrinkRetries Int
   deriving (Eq, Ord, Show, Num, Enum, Real, Integral, Lift)
 
 -- | The maximum size to use in tests before restarting at a size of 0
@@ -319,7 +318,7 @@ newtype ShrinkRetries =
 -- @
 --
 newtype SizeLimit =
-  SizeLimit Int64
+  SizeLimit Int
   deriving (Eq, Ord, Show, Num, Enum, Real, Integral, Lift)
 
 -- | A named collection of property tests.

--- a/hedgehog/src/Hedgehog/Internal/Range.hs
+++ b/hedgehog/src/Hedgehog/Internal/Range.hs
@@ -40,7 +40,6 @@ module Hedgehog.Internal.Range (
   , scaleExponentialFloat
   ) where
 
-import           Data.Int (Int64)
 import           Data.Bifunctor (bimap)
 
 import           Prelude hiding (minimum, maximum)
@@ -54,7 +53,7 @@ import           Prelude hiding (minimum, maximum)
 --
 newtype Size =
   Size {
-      unSize :: Int64
+      unSize :: Int
     } deriving (Eq, Ord, Num, Real, Enum, Integral)
 
 instance Show Size where

--- a/hedgehog/src/Hedgehog/Internal/Range.hs
+++ b/hedgehog/src/Hedgehog/Internal/Range.hs
@@ -40,6 +40,7 @@ module Hedgehog.Internal.Range (
   , scaleExponentialFloat
   ) where
 
+import           Data.Int (Int64)
 import           Data.Bifunctor (bimap)
 
 import           Prelude hiding (minimum, maximum)
@@ -53,7 +54,7 @@ import           Prelude hiding (minimum, maximum)
 --
 newtype Size =
   Size {
-      unSize :: Int
+      unSize :: Int64
     } deriving (Eq, Ord, Num, Real, Enum, Integral)
 
 instance Show Size where

--- a/hedgehog/src/Hedgehog/Internal/Runner.hs
+++ b/hedgehog/src/Hedgehog/Internal/Runner.hs
@@ -170,7 +170,7 @@ checkReport cfg size0 seed0 test0 updateUI =
     loop !tests !discards !size !seed !coverage0 = do
       updateUI $ Report tests discards coverage0 Running
 
-      if size > 99 then
+      if size > fromIntegral (propertySizeLimit cfg) then
         -- size has reached limit, reset to 0
         loop tests discards 0 seed coverage0
 


### PR DESCRIPTION
and bumped other "limit" options to Int64.

Hey there. I am currently working on integrating "enumerative testing" to Hedgehog where, instead of randomly selecting values out of a given range we enumerate them exhaustively for small size (ala SmallCheck) then switch to random selection when there are too many combinations. I think that this is a way to get a nice coverage, especially of "business" data structures which are not recursive. 

However in order to integrate those `Enumerates` (coming from the `testing-feat` package) as generators we need to be able to "index" into them. However the only two parameters passed to a `GenT` are `Size` and `Seed`. I would like to use `Size` for my indexing into an enumeration so I need it to be able to go from `0` to a configured value.

So I am proposing to be able to have the currently hard-coded `99` size value as a configuration option, which shouldn't hurt any current user. At the same time, those enumerations can be quite large so the size needs to be bounded and `Int64` is a good candidate for that. I know this has some memory implications but I don't think that they matter much for test execution.

Here is an example of how I am using all of this to enumerate the values of a datatype: https://github.com/etorreborre/registry-hedgehog/blob/testing-feat/test/Test/Data/Registry/TestingFeatSpec.hs#L39
