### PR TITLE
use the current number of tests in a generator

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,8 +25,8 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: haskell/actions/setup@v1
+      - uses: actions/checkout@v3
+      - uses: haskell/actions/setup@v2
         id: setup-haskell-cabal
         with:
           ghc-version: ${{ matrix.ghc }}
@@ -35,7 +35,7 @@ jobs:
         run: |
           cabal v2-update
           cabal v2-freeze $CONFIG
-      - uses: actions/cache@v2.1.5
+      - uses: actions/cache@v3
         with:
           path: |
             ${{ steps.setup-haskell-cabal.outputs.cabal-store }}

--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -111,6 +111,7 @@ library
     Hedgehog.Internal.Shrink
     Hedgehog.Internal.Source
     Hedgehog.Internal.State
+    Hedgehog.Internal.TestCount
     Hedgehog.Internal.TH
     Hedgehog.Internal.Tree
     Hedgehog.Internal.Tripping

--- a/hedgehog/src/Hedgehog/Internal/Gen.hs
+++ b/hedgehog/src/Hedgehog/Internal/Gen.hs
@@ -228,6 +228,7 @@ import           Hedgehog.Internal.Prelude hiding (either, maybe, seq)
 import           Hedgehog.Internal.Seed (Seed)
 import qualified Hedgehog.Internal.Seed as Seed
 import qualified Hedgehog.Internal.Shrink as Shrink
+import           Hedgehog.Internal.TestCount (TestCount(..))
 import           Hedgehog.Internal.Tree (Tree, TreeT(..), NodeT(..))
 import qualified Hedgehog.Internal.Tree as Tree
 import           Hedgehog.Range (Size, Range)
@@ -252,14 +253,14 @@ type Gen =
 --
 newtype GenT m a =
   GenT {
-      unGenT :: Size -> Seed -> TreeT (MaybeT m) a
+      unGenT :: TestCount -> Size -> Seed -> TreeT (MaybeT m) a
     }
 
 -- | Runs a generator, producing its shrink tree.
 --
-runGenT :: Size -> Seed -> GenT m a -> TreeT (MaybeT m) a
-runGenT size seed (GenT m) =
-  m size seed
+runGenT :: TestCount -> Size -> Seed -> GenT m a -> TreeT (MaybeT m) a
+runGenT tests size seed (GenT m) =
+  m tests size seed
 
 -- | Run a generator, producing its shrink tree.
 --
@@ -268,21 +269,21 @@ runGenT size seed (GenT m) =
 evalGen :: Size -> Seed -> Gen a -> Maybe (Tree a)
 evalGen size seed =
   Tree.mapMaybe id .
-  evalGenT size seed
+  evalGenT 0 size seed
 
 -- | Runs a generator, producing its shrink tree.
 --
-evalGenT :: Monad m => Size -> Seed -> GenT m a -> TreeT m (Maybe a)
-evalGenT size seed =
+evalGenT :: Monad m => TestCount -> Size -> Seed -> GenT m a -> TreeT m (Maybe a)
+evalGenT tests size seed =
   runDiscardEffectT .
-  runGenT size seed
+  runGenT tests size seed
 
 -- | Map over a generator's shrink tree.
 --
 mapGenT :: (TreeT (MaybeT m) a -> TreeT (MaybeT n) b) -> GenT m a -> GenT n b
 mapGenT f gen =
-  GenT $ \size seed ->
-    f (runGenT size seed gen)
+  GenT $ \tests size seed ->
+    f (runGenT tests size seed gen)
 
 -- | Lift a predefined shrink tree in to a generator, ignoring the seed and the
 --   size.
@@ -305,7 +306,7 @@ fromTreeT x =
 --
 fromTreeMaybeT :: MonadGen m => TreeT (MaybeT (GenBase m)) a -> m a
 fromTreeMaybeT x =
-  fromGenT . GenT $ \_ _ ->
+  fromGenT . GenT $ \_ _ _->
     x
 
 -- | Observe a generator's shrink tree.
@@ -489,8 +490,8 @@ instance (
 
 instance Functor m => Functor (GenT m) where
   fmap f gen =
-    GenT $ \seed size ->
-      fmap f (runGenT seed size gen)
+    GenT $ \tests size seed ->
+      fmap f (runGenT tests size seed gen)
 
 --
 -- implementation: parallel shrinking
@@ -500,12 +501,12 @@ instance Monad m => Applicative (GenT m) where
     fromTreeMaybeT . pure
 
   (<*>) f m =
-    GenT $ \ size seed ->
+    GenT $ \ tests size seed ->
       case Seed.split seed of
         (sf, sm) ->
           uncurry ($) <$>
-            runGenT size sf f `mzip`
-            runGenT size sm m
+            runGenT tests size sf f `mzip`
+            runGenT tests size sm m
 
 --
 -- implementation: satisfies law (ap = <*>)
@@ -514,22 +515,22 @@ instance Monad m => Applicative (GenT m) where
 --  pure =
 --    fromTreeMaybeT . pure
 --  (<*>) f m =
---    GenT $ \ size seed ->
+--    GenT $ \ tests size seed ->
 --      case Seed.split seed of
 --        (sf, sm) ->
---          runGenT size sf f <*>
---          runGenT size sm m
+--          runGenT tests size sf f <*>
+--          runGenT tests size sm m
 
 instance Monad m => Monad (GenT m) where
   return =
     pure
 
   (>>=) m k =
-    GenT $ \size seed ->
+    GenT $ \tests size seed ->
       case Seed.split seed of
         (sk, sm) ->
-          runGenT size sk . k =<<
-          runGenT size sm m
+          runGenT tests size sk . k =<<
+          runGenT tests size sm m
 
 #if __GLASGOW_HASKELL__ < 808
   fail =
@@ -552,11 +553,11 @@ instance Monad m => MonadPlus (GenT m) where
     fromTreeMaybeT mzero
 
   mplus x y =
-    GenT $ \size seed ->
+    GenT $ \tests size seed ->
       case Seed.split seed of
         (sx, sy) ->
-          runGenT size sx x `mplus`
-          runGenT size sy y
+          runGenT tests size sx x `mplus`
+          runGenT tests size sy y
 
 instance MonadTrans GenT where
   lift =
@@ -590,11 +591,11 @@ embedGenT ::
   -> GenT m b
   -> GenT n b
 embedGenT f gen =
-  GenT $ \size seed ->
+  GenT $ \tests size seed ->
     case Seed.split seed of
       (sf, sg) ->
-        (runGenT size sf . f) `embedTreeMaybeT`
-        (runGenT size sg gen)
+        (runGenT tests size sf . f) `embedTreeMaybeT`
+        (runGenT tests size sg gen)
 
 instance MMonad GenT where
   embed =
@@ -602,8 +603,8 @@ instance MMonad GenT where
 
 distributeGenT :: Transformer t GenT m => GenT (t m) a -> t (GenT m) a
 distributeGenT x =
-  join . lift . GenT $ \size seed ->
-    pure . hoist fromTreeMaybeT . distributeT . hoist distributeT $ runGenT size seed x
+  join . lift . GenT $ \tests size seed ->
+    pure . hoist fromTreeMaybeT . distributeT . hoist distributeT $ runGenT tests size seed x
 
 instance MonadTransDistributive GenT where
   type Transformer t GenT m = (
@@ -631,7 +632,7 @@ instance MonadBase b m => MonadBase b (GenT m) where
     lift . liftBase
 
 #if __GLASGOW_HASKELL__ >= 806
-deriving via (ReaderT Size (ReaderT Seed (TreeT (MaybeT m))))
+deriving via (ReaderT TestCount (ReaderT Size (ReaderT Seed (TreeT (MaybeT m)))))
   instance MonadBaseControl b m => MonadBaseControl b (GenT m)
 #else
 instance MonadBaseControl b m => MonadBaseControl b (GenT m) where
@@ -639,7 +640,7 @@ instance MonadBaseControl b m => MonadBaseControl b (GenT m) where
   liftBaseWith g = gloopToGen $ liftBaseWith $ \q -> g (\gen -> q (genToGloop gen))
   restoreM = gloopToGen . restoreM
 
-type GloopT m = ReaderT Size (ReaderT Seed (TreeT (MaybeT m)))
+type GloopT m = ReaderT TestCount (ReaderT Size (ReaderT Seed (TreeT (MaybeT m))))
 
 gloopToGen :: GloopT m a -> GenT m a
 gloopToGen = coerce
@@ -654,11 +655,11 @@ instance MonadThrow m => MonadThrow (GenT m) where
 
 instance MonadCatch m => MonadCatch (GenT m) where
   catch m onErr =
-    GenT $ \size seed ->
+    GenT $ \tests size seed ->
       case Seed.split seed of
         (sm, se) ->
-          (runGenT size sm m) `catch`
-          (runGenT size se . onErr)
+          (runGenT tests size sm m) `catch`
+          (runGenT tests size se . onErr)
 
 instance MonadReader r m => MonadReader r (GenT m) where
   ask =
@@ -680,21 +681,21 @@ instance MonadWriter w m => MonadWriter w (GenT m) where
   tell =
     lift . tell
   listen m =
-    GenT $ \size seed ->
-      listen $ runGenT size seed m
+    GenT $ \tests size seed ->
+      listen $ runGenT tests size seed m
   pass m =
-    GenT $ \size seed ->
-      pass $ runGenT size seed m
+    GenT $ \tests size seed ->
+      pass $ runGenT tests size seed m
 
 instance MonadError e m => MonadError e (GenT m) where
   throwError =
     lift . throwError
   catchError m onErr =
-    GenT $ \size seed ->
+    GenT $ \tests size seed ->
       case Seed.split seed of
         (sm, se) ->
-          (runGenT size sm m) `catchError`
-          (runGenT size se . onErr)
+          (runGenT tests size sm m) `catchError`
+          (runGenT tests size se . onErr)
 
 instance MonadResource m => MonadResource (GenT m) where
   liftResourceT =
@@ -707,7 +708,7 @@ instance MonadResource m => MonadResource (GenT m) where
 --
 generate :: MonadGen m => (Size -> Seed -> a) -> m a
 generate f =
-  fromGenT . GenT $ \size seed ->
+  fromGenT . GenT $ \_ size seed ->
     pure (f size seed)
 
 ------------------------------------------------------------------------
@@ -749,7 +750,7 @@ resize size gen =
 scale :: MonadGen m => (Size -> Size) -> m a -> m a
 scale f =
   withGenT $ \gen ->
-    GenT $ \size0 seed ->
+    GenT $ \tests size0 seed ->
       let
         size =
           f size0
@@ -757,7 +758,7 @@ scale f =
         if size < 0 then
           error "Hedgehog.Gen.scale: negative size"
         else
-          runGenT size seed gen
+          runGenT tests size seed gen
 
 -- | Make a generator smaller by scaling its size parameter.
 --
@@ -836,7 +837,7 @@ integral range =
             binarySearchTree origin_ root
 
   in
-    fromGenT . GenT $ \size seed ->
+    fromGenT . GenT $ \_ size seed ->
       createTree $ integralHelper range size seed
 
 -- | Generates a random integral number in the [inclusive,inclusive] range.
@@ -1568,8 +1569,8 @@ deriving instance Traversable (Vec n)
 freeze :: MonadGen m => m a -> m (a, m a)
 freeze =
   withGenT $ \gen ->
-    GenT $ \size seed -> do
-      mx <- lift . lift . runMaybeT . runTreeT $ runGenT size seed gen
+    GenT $ \tests size seed -> do
+      mx <- lift . lift . runMaybeT . runTreeT $ runGenT tests size seed gen
       case mx of
         Nothing ->
           empty

--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -183,6 +183,7 @@ import qualified Hedgehog.Internal.Gen as Gen
 import           Hedgehog.Internal.Prelude
 import           Hedgehog.Internal.Show
 import           Hedgehog.Internal.Source
+import           Hedgehog.Internal.TestCount (TestCount(..))
 
 import           Language.Haskell.TH.Syntax (Lift)
 
@@ -300,12 +301,6 @@ data PropertyConfig =
 --
 newtype TestLimit =
   TestLimit Int
-  deriving (Eq, Ord, Show, Num, Enum, Real, Integral, Lift)
-
--- | The number of tests a property ran successfully.
---
-newtype TestCount =
-  TestCount Int
   deriving (Eq, Ord, Show, Num, Enum, Real, Integral, Lift)
 
 -- | The number of tests a property had to discard.

--- a/hedgehog/src/Hedgehog/Internal/Runner.hs
+++ b/hedgehog/src/Hedgehog/Internal/Runner.hs
@@ -339,14 +339,14 @@ checkReport cfg size0 seed0 test0 updateUI = do
               loop (tests + 1) discards (size + 1) s1 coverage0
             (Just _, Just shrinkPath) -> do
               node <-
-                runTreeT . evalGenT size s0 . runTestT $ unPropertyT test
+                runTreeT . evalGenT tests size s0 . runTestT $ unPropertyT test
               let
                 mkReport =
                   Report (tests + 1) discards coverage0 seed0
               mkReport <$> skipToShrink shrinkPath (updateUI . mkReport) node
             _ -> do
               node@(NodeT x _) <-
-                runTreeT . evalGenT size s0 . runTestT $ unPropertyT test
+                runTreeT . evalGenT tests size s0 . runTestT $ unPropertyT test
               case x of
                 Nothing ->
                   loop tests (discards + 1) (size + 1) s1 coverage0

--- a/hedgehog/src/Hedgehog/Internal/TestCount.hs
+++ b/hedgehog/src/Hedgehog/Internal/TestCount.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE DeriveLift #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+module Hedgehog.Internal.TestCount where
+
+import          Prelude
+import          Language.Haskell.TH.Syntax (Lift)
+
+-- | The number of tests a property ran successfully.
+--
+newtype TestCount =
+  TestCount Int
+  deriving (Eq, Ord, Show, Num, Enum, Real, Integral, Lift)


### PR DESCRIPTION
@jacobstanley if you want to get a feel for the changes involved in using the number of tests in a generator. Note that:

 - I had to put the `TestCount` into its own file
 - I arbitrarily passed `0` to `evalGen`, maybe we should add another function `evalGenAt :: TestCount ...` taking the tests number as a parameter as well