### PR TITLE
Include location of failed assertion in report

### DIFF
--- a/hedgehog/src/Hedgehog/Internal/Report.hs
+++ b/hedgehog/src/Hedgehog/Internal/Report.hs
@@ -760,12 +760,14 @@ ppResult name (Report tests discards coverage result) = do
         ppCoverage tests coverage
 
 ppFailedAtLocation :: Maybe Span -> Doc Markup
-ppFailedAtLocation (Just span') =
-  "at" <+>
-  WL.text (spanFile span') <> ":" <>
-  WL.pretty (unLineNo (spanStartLine span')) <> ":" <>
-  WL.pretty (unColumnNo (spanStartColumn span'))
-ppFailedAtLocation Nothing = mempty
+ppFailedAtLocation = \case
+  Just x ->
+    "at" <+>
+    WL.text (spanFile x) <> ":" <>
+    WL.pretty (unLineNo (spanStartLine x)) <> ":" <>
+    WL.pretty (unColumnNo (spanStartColumn x))
+  Nothing ->
+    mempty
 
 ppCoverage :: TestCount -> Coverage CoverCount -> [Doc Markup]
 ppCoverage tests x =


### PR DESCRIPTION
Fixes #306.

Adds the location of the failed assertion (taken from the `Span` value of the failure report). Example output:

```
 ✗ <interactive> failed at test/Test/Hedgehog/Applicative.hs:91:11
    after 1 test.

       ┏━━ test/Test/Hedgehog/Applicative.hs ━━━
    69 ┃ ...

```

This enables editors to more easily parse the location of failed test assertions, and provide links/jump functionality. This has been tested with Emacs.