### PR TITLE
Fix some formatting bugs in Haddock

### DIFF
--- a/hedgehog/src/Hedgehog/Internal/Gen.hs
+++ b/hedgehog/src/Hedgehog/Internal/Gen.hs
@@ -852,7 +852,7 @@ word64 =
 
 -- | Generates a random floating-point number in the @[inclusive,exclusive)@ range.
 --
---   This generator works the same as 'integral', but for floating point numbers.
+--   /This generator works the same as 'integral', but for floating point numbers./
 --
 realFloat :: (MonadGen m, RealFloat a) => Range a -> m a
 realFloat range =
@@ -1256,7 +1256,7 @@ filterT p gen0 =
 
 -- | Runs a 'Maybe' generator until it produces a 'Just'.
 --
---   This is implemented using 'filter' and has the same caveats.
+--   /This is implemented using 'filter' and has the same caveats./
 --
 just :: (MonadGen m, GenBase m ~ Identity) => m (Maybe a) -> m a
 just g = do
@@ -1269,7 +1269,7 @@ just g = do
 
 -- | Runs a 'Maybe' generator until it produces a 'Just'.
 --
---   This is implemented using 'filter' and has the same caveats.
+--   /This is implemented using 'filter' and has the same caveats./
 --
 justT :: MonadGen m => m (Maybe a) -> m a
 justT g = do
@@ -1525,8 +1525,8 @@ subsequence xs =
 
 -- | Generates a random permutation of a list.
 --
---   This shrinks towards the order of the list being identical to the input
---   list.
+--   /This shrinks towards the order of the list being identical to the input/
+--   /list./
 --
 shuffle :: MonadGen m => [a] -> m [a]
 shuffle = \case

--- a/hedgehog/src/Hedgehog/Internal/Gen.hs
+++ b/hedgehog/src/Hedgehog/Internal/Gen.hs
@@ -916,8 +916,8 @@ enum lo hi =
 -- enumBounded :: 'Gen' 'Bool'
 -- @
 --
---   /This is implemented in terms of the 'Enum' class, and thus may be
---    partial for integral types larger than 'Int', e.g. 'Word64'./
+--   /This is implemented in terms of the 'Enum' class, and thus may be/
+--   /partial for integral types larger than 'Int', e.g. 'Word64'./
 enumBounded :: (MonadGen m, Enum a, Bounded a) => m a
 enumBounded =
   enum minBound maxBound

--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -420,8 +420,8 @@ newtype LabelName =
 
 -- | The extent to which a test is covered by a classifier.
 --
---   /When a classifier's coverage does not exceed the required minimum, the
---   test will be failed./
+--   /When a classifier's coverage does not exceed the required minimum, the/
+--   /test will be failed./
 --
 data Label a =
   MkLabel {
@@ -433,8 +433,8 @@ data Label a =
 
 -- | The extent to which all classifiers cover a test.
 --
---   /When a given classification's coverage does not exceed the required
---   minimum, the test will be failed./
+--   /When a given classification's coverage does not exceed the required/
+--   /minimum, the test will be failed./
 --
 newtype Coverage a =
   Coverage {
@@ -699,10 +699,10 @@ assert b = do
 --   diff x (<=) 'r'
 -- @
 --
---   /This function behaves like the unix `diff` tool, which gives a `0` exit
---   code if the compared files are identical, or a `1` exit code code
---   otherwise. Like unix `diff`, if the arguments fail the comparison, a diff
---   is shown./
+--   /This function behaves like the unix `diff` tool, which gives a `0` exit/
+--   /code if the compared files are identical, or a `1` exit code code/
+--   /otherwise. Like unix `diff`, if the arguments fail the comparison, a diff/
+--   /is shown./
 --
 diff :: (MonadTest m, Show a, Show b, HasCallStack) => a -> (a -> b -> Bool) -> b -> m ()
 diff x op y = do
@@ -1073,7 +1073,7 @@ cover minimum_ name covered =
 --    prop_with_classifier =
 --      property $ do
 --        xs <- forAll $ Gen.list (Range.linear 0 100) Gen.alpha
---        for_ xs $ \x -> do
+--        for_ xs $ \\x -> do
 --          classify "newborns" $ x == 0
 --          classify "children" $ x > 0 && x < 13
 --          classify "teens" $ x > 12 && x < 20

--- a/hedgehog/src/Hedgehog/Internal/Range.hs
+++ b/hedgehog/src/Hedgehog/Internal/Range.hs
@@ -253,7 +253,7 @@ linearBounded =
 -- | Construct a range which scales the second bound relative to the size
 --   parameter.
 --
---   This works the same as 'linear', but for fractional values.
+--   /This works the same as 'linear', but for fractional values./
 --
 linearFrac :: (Fractional a, Ord a) => a -> a -> Range a
 linearFrac x y =
@@ -261,7 +261,7 @@ linearFrac x y =
 
 -- | Construct a range which scales the bounds relative to the size parameter.
 --
---   This works the same as 'linearFrom', but for fractional values.
+--   /This works the same as 'linearFrom', but for fractional values./
 --
 linearFracFrom :: (Fractional a, Ord a) => a -> a -> a -> Range a
 linearFracFrom z x y =
@@ -400,7 +400,7 @@ exponentialBounded =
 -- | Construct a range which scales the second bound exponentially relative to
 --   the size parameter.
 --
---   This works the same as 'exponential', but for floating-point values.
+--   /This works the same as 'exponential', but for floating-point values./
 --
 --   >>> bounds 0 $ exponentialFloat 0 10
 --   (0.0,0.0)
@@ -418,7 +418,7 @@ exponentialFloat x y =
 -- | Construct a range which scales the bounds exponentially relative to the
 --   size parameter.
 --
---   This works the same as 'exponentialFrom', but for floating-point values.
+--   /This works the same as 'exponentialFrom', but for floating-point values./
 --
 --   >>> bounds 0 $ exponentialFloatFrom 0 (-10) 20
 --   (0.0,0.0)

--- a/hedgehog/src/Hedgehog/Internal/State.hs
+++ b/hedgehog/src/Hedgehog/Internal/State.hs
@@ -97,7 +97,7 @@ instance Show Name where
 --   previous action in a generator without knowing the value of the result
 --   (e.g., to get the ID of a previously-created user).
 --
---   Symmbolic variables provide a token to stand in for the actual variables at
+--   Symbolic variables provide a token to stand in for the actual variables at
 --   generation time (and in 'Require'/'Update' callbacks). At execution time,
 --   real values are available, so your execute actions work on 'Concrete'
 --   variables.


### PR DESCRIPTION
- Some cases of `/.../` spread across lines
- One case of `\ -> ...` needing another backslash.
- Fix one typo (Symmbolic -> Symbolic)
- Add `/.../` formatting for consistency: This appears to be the style.