### PR TITLE
Remove `undefined` in GenT's MonadWriter instance

### DIFF
--- a/hedgehog/src/Hedgehog/Internal/Gen.hs
+++ b/hedgehog/src/Hedgehog/Internal/Gen.hs
@@ -665,12 +665,12 @@ instance MonadWriter w m => MonadWriter w (GenT m) where
     lift . writer
   tell =
     lift . tell
-  listen =
-    undefined
-    --mapGenT listen
-  pass =
-    undefined
-    --mapGenT pass
+  listen m =
+    GenT $ \size seed ->
+      listen $ runGenT size seed m
+  pass m =
+    GenT $ \size seed ->
+      pass $ runGenT size seed m
 
 instance MonadError e m => MonadError e (GenT m) where
   throwError =


### PR DESCRIPTION
Not sure why these weren't implemented.

These aren't the most commonly used functions, but `undefined` is worth removing nonetheless.
