### PR TITLE
Speed up shuffle

### DIFF
--- a/hedgehog/src/Hedgehog/Gen.hs
+++ b/hedgehog/src/Hedgehog/Gen.hs
@@ -90,6 +90,7 @@ module Hedgehog.Gen (
   -- ** Combinations & Permutations
   , subsequence
   , shuffle
+  , shuffleSeq
 
   -- ** Abstract State Machine
   , sequential


### PR DESCRIPTION
* Add `shuffleSeq` to shuffle sequences.

* Use `shuffleSeq` to implement `shuffle` much more efficiently. The shuffling
  algorithm we use finds and removes an arbitrary element, which sequences
  can do in logarithmic time and space rather than linear time and
  space. It also uses `length`, which is constant time for sequences and
  linear time for lists.

* Bump lower bound on `containers`. We could avoid this, if necessary,
  by not using pattern synonyms for sequences.