### PR TITLE
Reimplement splits

### DIFF
--- a/hedgehog/src/Hedgehog/Internal/Range.hs
+++ b/hedgehog/src/Hedgehog/Internal/Range.hs
@@ -48,8 +48,9 @@ import           Prelude hiding (minimum, maximum)
 -- >>> import Data.Int (Int8)
 -- >>> let x = 3
 
--- | Tests are parameterized by the size of the randomly-generated data, the
---   meaning of which depends on the particular generator used.
+-- | Tests are parameterized by the size of the randomly-generated data. The
+--   meaning of a 'Size' value depends on the particular generator used, but
+--   it must always be a number between 0 and 99 inclusive.
 --
 newtype Size =
   Size {

--- a/hedgehog/src/Hedgehog/Internal/Tree.hs
+++ b/hedgehog/src/Hedgehog/Internal/Tree.hs
@@ -321,13 +321,14 @@ mapMaybeT p m =
 --   ]
 --
 splits :: [a] -> [([a], a, [a])]
--- This implementation is significantly more efficient than the others I've
--- tried when the lists are long, thanks to the carefully optimized
--- implementation of Data.List.inits.
-splits = \xs -> go (List.inits xs) xs
-  where
-    go (front : fronts) (x : xs) = (front, x, xs) : go fronts xs
-    go _ _ = []
+splits xs0 =
+  let
+    go (front : fronts) (x : xs) =
+      (front, x, xs) : go fronts xs
+    go _ _ =
+      []
+  in
+    go (List.inits xs0) xs0
 
 dropOne :: Monad m => [NodeT m a] -> [TreeT m [a]]
 dropOne ts = do


### PR DESCRIPTION
Using `Data.List.inits` to produce the initial segments saves
quite a bit of time.