### PR TITLE
Make `shuffleSeq` accessible via `Hedgehog.Internal.Gen`

### DIFF
--- a/hedgehog/src/Hedgehog/Gen.hs
+++ b/hedgehog/src/Hedgehog/Gen.hs
@@ -90,7 +90,6 @@ module Hedgehog.Gen (
   -- ** Combinations & Permutations
   , subsequence
   , shuffle
-  , shuffleSeq
 
   -- ** Abstract State Machine
   , sequential


### PR DESCRIPTION
As discussed with @jacobstanley and as commented earlier at https://github.com/hedgehogqa/haskell-hedgehog/commit/ecad248f239ddccbbfbe4889b4c2f89851ae2141.
