### PR TITLE
Bump `containers` to `>= 0.5.8` simplifying `shuffleSeq`

### DIFF
--- a/hedgehog-example/hedgehog-example.cabal
+++ b/hedgehog-example/hedgehog-example.cabal
@@ -58,7 +58,7 @@ library
       hedgehog
     , hedgehog-quickcheck
     , base                            >= 3          && < 5
-    , containers                      >= 0.4        && < 0.7
+    , containers                      >= 0.5.8      && < 0.7
     , filepath                        >= 1.3        && < 1.5
     , hashtables                      >= 1.2        && < 1.3
     , mmorph                          >= 1.0        && < 1.2

--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -53,7 +53,7 @@ library
     , async                           >= 2.0        && < 2.3
     , bytestring                      >= 0.10       && < 0.11
     , concurrent-output               >= 1.7        && < 1.11
-    , containers                      >= 0.4        && < 0.7
+    , containers                      >= 0.5.8      && < 0.7
     , directory                       >= 1.2        && < 1.4
     , erf                             >= 2.0        && < 2.1
     , exceptions                      >= 0.7        && < 0.11
@@ -137,7 +137,7 @@ test-suite test
   build-depends:
       hedgehog
     , base                            >= 3          && < 5
-    , containers                      >= 0.4        && < 0.7
+    , containers                      >= 0.5.8      && < 0.7
     , mmorph                          >= 1.0        && < 1.2
     , mtl                             >= 2.1        && < 2.3
     , pretty-show                     >= 1.6        && < 1.10

--- a/hedgehog/src/Hedgehog/Internal/Gen.hs
+++ b/hedgehog/src/Hedgehog/Internal/Gen.hs
@@ -1607,26 +1607,11 @@ shuffleSeq xs =
     pure Seq.empty
   else do
     n <- integral $ Range.constant 0 (length xs - 1)
-#if MIN_VERSION_containers(0,5,8)
-    -- Data.Sequence should offer a version of deleteAt that returns the
-    -- deleted element, but it does not currently do so. Lookup followed
-    -- by deletion seems likely faster than splitting and then appending,
-    -- but I haven't actually tested that. It's certainly easier to see
-    -- what's going on.
     case Seq.lookup n xs of
       Just y ->
         (y Seq.<|) <$> shuffleSeq (Seq.deleteAt n xs)
       Nothing ->
         error "Hedgehog.Gen.shuffleSeq: internal error, lookup in empty sequence"
-#else
-    case Seq.splitAt n xs of
-      (beginning, end) ->
-        case Seq.viewl end of
-          y Seq.:< end' ->
-            (y Seq.<|) <$> shuffleSeq (beginning Seq.>< end')
-          Seq.EmptyL ->
-            error "Hedgehog.Gen.shuffleSeq: internal error, lookup in empty sequence"
-#endif
 
 ------------------------------------------------------------------------
 -- Sampling


### PR DESCRIPTION
Bumping can break other peoples cabal, it's the unfortunate problem that [`containers` ships with GHC itself]( https://gitlab.haskell.org/ghc/ghc/wikis/commentary/libraries/version-history). — Merge with care.