### PR TITLE
Remove testGroup "GenT" from hedgehog-test-laws since we skip it

### DIFF
--- a/hedgehog-test-laws/test/test.hs
+++ b/hedgehog-test-laws/test/test.hs
@@ -2,23 +2,18 @@
 module Main where
 
 import           Control.Applicative (liftA2)
-import           Control.Monad.Trans.Maybe (MaybeT(..))
 
 import           Data.Functor.Classes (Eq1(..))
 
-import           Hedgehog.Internal.Gen (GenT(..))
-import           Hedgehog.Internal.Range (Size(..))
-import           Hedgehog.Internal.Seed (Seed(..))
 import           Hedgehog.Internal.Tree (TreeT(..), NodeT(..))
 
-import           Test.QuickCheck (Arbitrary(..), Arbitrary1(..), CoArbitrary(..))
-import           Test.QuickCheck (choose, vector, coarbitraryIntegral, property)
+import           Test.QuickCheck (Arbitrary(..), Arbitrary1(..))
+import           Test.QuickCheck (choose, vector)
 
 import           Test.QuickCheck (arbitrary1)
 import           Test.QuickCheck.Checkers (EqProp(..), eq)
 import           Test.QuickCheck.Classes (applicative, monad, monadApplicative)
 import           Test.Tasty (TestTree, defaultMain, testGroup)
-import           Test.Tasty.ExpectedFailure (ignoreTest)
 import           Test.Tasty.QuickCheck (testProperties)
 
 main :: IO ()
@@ -44,12 +39,6 @@ instances =
           , monad (undefined :: NodeT Maybe (Bool, Char, Int))
           , monadApplicative (undefined :: NodeT (Either Bool) (Char, Int))
           ]
-    , testGroup "GenT" $
-        ignoreTest . testBatch <$> [
-            applicative (undefined :: GenT Maybe (Bool, Char, Int))
-          , monad (undefined :: GenT Maybe (Bool, Char, Int))
-          , monadApplicative (undefined :: GenT (Either Bool) (Char, Int))
-          ]
     ]
 
 ------------------------------------------------------------------------
@@ -74,29 +63,3 @@ instance (Arbitrary1 m, Arbitrary a) => Arbitrary (NodeT m a) where
   arbitrary = do
     n <- choose (0, 2)
     liftA2 NodeT arbitrary (vector n)
-
--- GenT
-
-instance Arbitrary Size where
-  arbitrary = Size <$> arbitrary
-
-instance CoArbitrary Size where
-  coarbitrary = coarbitraryIntegral
-
-instance Arbitrary Seed where
-  arbitrary = liftA2 Seed arbitrary ((\n -> 2 * n + 1) <$> arbitrary)
-
-instance CoArbitrary Seed where
-  coarbitrary (Seed v g) = coarbitrary (v, g)
-
-instance (Arbitrary1 m) => Arbitrary1 (MaybeT m) where
-  liftArbitrary = fmap MaybeT . liftArbitrary . liftArbitrary
-
-instance Show (GenT m a) where
-  show _ = "GenT { unGenT = <function> }"
-
-instance (Eq1 m, Eq a) => EqProp (GenT m a) where
-  GenT f0 =-= GenT f1 = property $ liftA2 (=-=) f0 f1
-
-instance (Arbitrary1 m, Arbitrary a) => Arbitrary (GenT m a) where
-  arbitrary = GenT <$> arbitrary


### PR DESCRIPTION
Or there's a valid reason to keep those? @jacobstanley 