### PR TITLE
Bump pretty-show to 1.10 which supports quasi-quotes

### DIFF
--- a/hedgehog-example/hedgehog-example.cabal
+++ b/hedgehog-example/hedgehog-example.cabal
@@ -39,6 +39,7 @@ library
     , Test.Example.Coverage
     , Test.Example.Exception
     , Test.Example.List
+    , Test.Example.QuasiShow
     , Test.Example.QuickCheck
     , Test.Example.References
     , Test.Example.Registry
@@ -58,10 +59,11 @@ library
     , mmorph                          >= 1.0        && < 1.2
     , mtl                             >= 2.1        && < 2.3
     , parsec                          >= 3.1        && < 3.2
-    , pretty-show                     >= 1.6        && < 1.10
+    , pretty-show                     >= 1.6        && < 1.11
     , process                         >= 1.2        && < 1.7
     , QuickCheck                      >= 2.7        && < 2.14
     , resourcet                       >= 1.1        && < 1.3
+    , template-haskell                >= 2.10       && < 2.16
     , temporary                       >= 1.3        && < 1.4
     , temporary-resourcet             >= 0.1        && < 0.2
     , text                            >= 1.1        && < 1.3

--- a/hedgehog-example/src/Test/Example/QuasiShow.hs
+++ b/hedgehog-example/src/Test/Example/QuasiShow.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE DeriveLift #-}
+{-# LANGUAGE DoAndIfThenElse #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Test.Example.QuasiShow where
+
+import           Hedgehog
+import qualified Hedgehog.Gen as Gen
+
+import           Language.Haskell.TH (Q, Exp)
+import           Language.Haskell.TH.Quote (QuasiQuoter(..))
+import           Language.Haskell.TH.Syntax (Lift(..))
+
+
+newtype Foo =
+  Foo {
+      unFoo :: String
+    } deriving (Eq, Ord, Lift)
+
+-- demo pretty-show supports quasi-quote syntax
+instance Show Foo where
+  showsPrec _ x =
+    showString ("[foo|" ++ unFoo x ++ "|]")
+
+data SomeData =
+  SomeData {
+      someFoo1 :: Foo
+    , someFoo2 :: Foo
+    } deriving (Eq, Ord, Show)
+
+genFoo :: Gen Foo
+genFoo =
+  Foo <$> Gen.element ["kick", "flip", "flap"]
+
+prop_foo :: Property
+prop_foo =
+  property $ do
+    x <- forAll (SomeData <$> genFoo <*> genFoo)
+    x === SomeData (Foo "quasi") (Foo "quoted")
+--  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+--  │ ━━━ Failed (- lhs) (+ rhs) ━━━
+--  │ - SomeData { someFoo1 = [foo|kick|] , someFoo2 = [foo|kick|] }
+--  │ + SomeData { someFoo1 = [foo|quasi|] , someFoo2 = [foo|quoted|] }
+
+tests :: IO Bool
+tests =
+  checkParallel $$(discover)
+
+
+------------------------------------------------------------------------
+-- Can't actually use this in the same file we define it,
+-- but this is what the quasi-quoter would look like.
+
+mkQQ :: ([Char] -> Q Exp) -> QuasiQuoter
+mkQQ f =
+  let
+    no c =
+      const (fail ("This QQ produces expressions, not " ++ c))
+  in
+    QuasiQuoter f (no "patterns") (no "types") (no "declarations")
+
+foo :: QuasiQuoter
+foo =
+  mkQQ (\str -> lift (Foo str))

--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -63,7 +63,7 @@ library
     , mmorph                          >= 1.0        && < 1.2
     , monad-control                   >= 1.0        && < 1.1
     , mtl                             >= 2.1        && < 2.3
-    , pretty-show                     >= 1.6        && < 1.10
+    , pretty-show                     >= 1.6        && < 1.11
     , primitive                       >= 0.6        && < 0.8
     , random                          >= 1.1        && < 1.2
     , resourcet                       >= 1.1        && < 1.3
@@ -142,7 +142,7 @@ test-suite test
     , containers                      >= 0.4        && < 0.7
     , mmorph                          >= 1.0        && < 1.2
     , mtl                             >= 2.1        && < 2.3
-    , pretty-show                     >= 1.6        && < 1.10
+    , pretty-show                     >= 1.6        && < 1.11
     , semigroups                      >= 0.16       && < 0.20
     , text                            >= 1.1        && < 1.3
     , transformers                    >= 0.3        && < 0.6


### PR DESCRIPTION
I have bumped the bounds and updated the hedgehog-example:
```
       ┏━━ hedgehog-example/src/Test/Example/QuasiShow.hs ━━━
    35 ┃ prop_foo :: Property
    36 ┃ prop_foo =
    37 ┃   property $ do
    38 ┃     x <- forAll (SomeData <$> genFoo <*> genFoo)
       ┃     │ SomeData { someFoo1 = [foo|kick|] , someFoo2 = [foo|kick|] }
    39 ┃     x === SomeData (Foo "quasi") (Foo "quoted")
       ┃     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       ┃     │ ━━━ Failed (- lhs) (+ rhs) ━━━
       ┃     │ - SomeData { someFoo1 = [foo|kick|] , someFoo2 = [foo|kick|] }
       ┃     │ + SomeData { someFoo1 = [foo|quasi|] , someFoo2 = [foo|quoted|] }
```

I updated the bounds on Hackage for `hedgehog-1.0.2` already.

This will be particularly useful for types like dates and times which have a sensible human readable representation.

By changing the `Show` instance to render with quasi-quotes you can stay within the unwritten rule that `Show` should be valid Haskell syntax to construct the value, while still having something which is very compact.

For example:
```
[time|2000-01-01T10:00:00|]
```
vs
```
DateTime { datetimeDate = Date { dateYear = Year { getYear = 2000 }, ... etc
```

The means you should be able to both read counterexamples easily and also paste them into your code for experimentation.

Related: https://github.com/yav/pretty-show/issues/40