### PR TITLE
Add filterT, justT, and mapMaybeT to Gen exports.

### DIFF
--- a/hedgehog/src/Hedgehog/Gen.hs
+++ b/hedgehog/src/Hedgehog/Gen.hs
@@ -67,8 +67,11 @@ module Hedgehog.Gen (
   -- ** Conditional
   , discard
   , filter
+  , filterT
   , mapMaybe
+  , mapMaybeT
   , just
+  , justT
 
   -- ** Collections
   , maybe


### PR DESCRIPTION
Allows the functionality these represent to be used when the GenBase m
is not Identity.