### PR TITLE
Add parallel' and sequential' that take a generator of commands

### DIFF
--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -134,6 +134,7 @@ test-suite test
     Test.Hedgehog.Filter
     Test.Hedgehog.Maybe
     Test.Hedgehog.Seed
+    Test.Hedgehog.State
     Test.Hedgehog.Text
     Test.Hedgehog.Zip
 

--- a/hedgehog/src/Hedgehog/Gen.hs
+++ b/hedgehog/src/Hedgehog/Gen.hs
@@ -96,7 +96,9 @@ module Hedgehog.Gen (
 
   -- ** Abstract State Machine
   , sequential
+  , sequential'
   , parallel
+  , parallel'
 
   -- * Sampling Generators
   , sample
@@ -107,6 +109,6 @@ module Hedgehog.Gen (
   ) where
 
 import           Hedgehog.Internal.Gen
-import           Hedgehog.Internal.State (sequential, parallel)
+import           Hedgehog.Internal.State (sequential, sequential', parallel, parallel')
 
 import           Prelude hiding (filter, print, maybe, map, seq)

--- a/hedgehog/test/Test/Hedgehog/State.hs
+++ b/hedgehog/test/Test/Hedgehog/State.hs
@@ -1,0 +1,96 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE KindSignatures #-}
+module Test.Hedgehog.State (tests) where
+
+import           Control.Monad.IO.Class (MonadIO)
+import           Data.IORef (IORef, readIORef, atomicModifyIORef', newIORef)
+import           Data.Kind (Type)
+import           Hedgehog
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+data State = State (IORef Int)
+
+createState :: IO State
+createState = State <$> newIORef 0
+
+counterValue :: State -> IO Int
+counterValue (State ref) = readIORef ref
+
+incrementState :: State -> IO ()
+incrementState (State ref) = atomicModifyIORef' ref (\x -> (x+1,()))
+
+decrementState :: State -> IO ()
+decrementState (State ref) = atomicModifyIORef' ref (\x -> (x-1,()))
+
+data Model (v :: Type -> Type) = Model Int
+
+data Increment (v :: Type -> Type) = Increment deriving Show
+instance HTraversable Increment where
+  htraverse _ Increment = pure Increment
+
+data Decrement (v :: Type -> Type) = Decrement deriving Show
+instance HTraversable Decrement where
+  htraverse _ Decrement = pure Decrement
+
+data GetCounter (v :: Type -> Type) = GetCounter deriving Show
+instance HTraversable GetCounter where
+  htraverse _ GetCounter = pure GetCounter
+
+cIncrement :: forall gen m. (MonadGen gen, MonadTest m, MonadIO m)
+           => State
+           -> Command gen m Model
+cIncrement s = Command gen exec cbs
+  where
+    gen :: Model Symbolic -> Maybe (gen (Increment Symbolic))
+    gen _ = Just (pure Increment)
+    exec :: Increment Concrete -> m ()
+    exec _ = evalIO (incrementState s)
+    cbs = [ Update $ \(Model value) _i _o -> Model (value + 1)
+          ]
+
+cDecrement :: forall gen m. (MonadGen gen, MonadTest m, MonadIO m)
+           => State
+           -> Command gen m Model
+cDecrement s = Command gen exec cbs
+  where
+    gen :: Model Symbolic -> Maybe (gen (Decrement Symbolic))
+    gen _ = Just (pure Decrement)
+    exec :: Decrement Concrete -> m ()
+    exec _ = evalIO (decrementState s)
+    cbs = [ Update $ \(Model value) _i _o -> Model (value - 1)
+          ]
+
+cGetCounter :: forall gen m. (MonadGen gen, MonadTest m, MonadIO m)
+           => State
+           -> Command gen m Model
+cGetCounter s = Command gen exec cbs
+  where
+    gen :: Model Symbolic -> Maybe (gen (GetCounter Symbolic))
+    gen _ = Just (pure GetCounter)
+    exec :: GetCounter Concrete -> m Int
+    exec _ = evalIO (counterValue s)
+    cbs = [ Ensure $ \_oldState (Model modelValue) _i retrievedValue -> modelValue === retrievedValue
+          ]
+
+commandsGen :: (MonadGen gen, MonadTest m, MonadIO m)
+            => State
+            -> gen (Command gen m Model)
+commandsGen s = Gen.frequency $
+  zipWith
+    (\freq cmd -> (freq, pure (cmd s)))
+    [1, 1, 2]
+    [cIncrement, cDecrement, cGetCounter]
+
+prop_commands_gen :: Property
+prop_commands_gen =
+  property $ do
+    state <- evalIO createState
+    let initialModel = Model 0
+    actions <- forAll $ Gen.sequential' (Range.linear 1 10) initialModel (commandsGen state)
+    executeSequential initialModel actions
+
+tests :: IO Bool
+tests =
+  checkParallel $$(discover)

--- a/hedgehog/test/test.hs
+++ b/hedgehog/test/test.hs
@@ -5,6 +5,7 @@ import qualified Test.Hedgehog.Confidence
 import qualified Test.Hedgehog.Filter
 import qualified Test.Hedgehog.Maybe
 import qualified Test.Hedgehog.Seed
+import qualified Test.Hedgehog.State
 import qualified Test.Hedgehog.Text
 import qualified Test.Hedgehog.Zip
 
@@ -17,6 +18,7 @@ main =
     , Test.Hedgehog.Filter.tests
     , Test.Hedgehog.Maybe.tests
     , Test.Hedgehog.Seed.tests
+    , Test.Hedgehog.State.tests
     , Test.Hedgehog.Text.tests
     , Test.Hedgehog.Zip.tests
     ]


### PR DESCRIPTION
More general than the unticked version that only takes a list and uses
`Gen.element` to choose one.

This allows you to, for example, use `Gen.frequency` to generate commands with different weights.