### PR TITLE
Add evalMaybe, evalMaybeM and evalEitherM

### DIFF
--- a/hedgehog/src/Hedgehog.hs
+++ b/hedgehog/src/Hedgehog.hs
@@ -111,7 +111,10 @@ module Hedgehog (
   , evalNF
   , evalM
   , evalIO
+  , evalMaybe
+  , evalMaybeM
   , evalEither
+  , evalEitherM
   , evalExceptT
 
   -- * Coverage
@@ -166,7 +169,7 @@ import           Hedgehog.Internal.Property (classify, cover)
 import           Hedgehog.Internal.Property (discard, failure, success)
 import           Hedgehog.Internal.Property (DiscardLimit, withDiscards)
 import           Hedgehog.Internal.Property (eval, evalNF, evalM, evalIO)
-import           Hedgehog.Internal.Property (evalEither, evalExceptT)
+import           Hedgehog.Internal.Property (evalMaybe, evalMaybeM, evalEither, evalEitherM, evalExceptT)
 import           Hedgehog.Internal.Property (footnote, footnoteShow)
 import           Hedgehog.Internal.Property (forAll, forAllWith)
 import           Hedgehog.Internal.Property (LabelName, MonadTest(..))

--- a/hedgehog/src/Hedgehog.hs
+++ b/hedgehog/src/Hedgehog.hs
@@ -111,11 +111,11 @@ module Hedgehog (
   , evalNF
   , evalM
   , evalIO
-  , evalMaybe
-  , evalMaybeM
   , evalEither
   , evalEitherM
   , evalExceptT
+  , evalMaybe
+  , evalMaybeM
 
   -- * Coverage
   , LabelName
@@ -169,7 +169,7 @@ import           Hedgehog.Internal.Property (classify, cover)
 import           Hedgehog.Internal.Property (discard, failure, success)
 import           Hedgehog.Internal.Property (DiscardLimit, withDiscards)
 import           Hedgehog.Internal.Property (eval, evalNF, evalM, evalIO)
-import           Hedgehog.Internal.Property (evalMaybe, evalMaybeM, evalEither, evalEitherM, evalExceptT)
+import           Hedgehog.Internal.Property (evalEither, evalEitherM, evalExceptT, evalMaybe, evalMaybeM)
 import           Hedgehog.Internal.Property (footnote, footnoteShow)
 import           Hedgehog.Internal.Property (forAll, forAllWith)
 import           Hedgehog.Internal.Property (LabelName, MonadTest(..))

--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -858,7 +858,7 @@ evalMaybe = \case
   Just x ->
     pure x
 
--- | Fails the test if the 'Maybe' is 'Nothing', otherwise returns the value in
+-- | Fails the test if the action throws an exception, or if the
 --   the 'Just'.
 --
 evalMaybeM :: (MonadTest m, Show a, MonadCatch m, HasCallStack) => m (Maybe a) -> m a

--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -854,7 +854,7 @@ evalExceptT m =
 evalMaybe :: (MonadTest m, Show a, HasCallStack) => Maybe a -> m a
 evalMaybe = \case
   Nothing ->
-    withFrozenCallStack $ failWith Nothing "the value was 'Nothing'"
+    withFrozenCallStack $ failWith Nothing "the value was Nothing"
   Just x ->
     pure x
 

--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -835,7 +835,7 @@ evalEither = \case
     pure x
 
 -- | Fails the test if the action throws an exception, or if the
---   'Either' is 'Left'.  Otherwise returns the value in the 'Right'.
+--   'Either' is 'Left', otherwise returns the value in the 'Right'.
 --
 evalEitherM :: (MonadTest m, Show x, MonadCatch m, HasCallStack) => m (Either x a) -> m a
 evalEitherM =

--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -859,7 +859,7 @@ evalMaybe = \case
     pure x
 
 -- | Fails the test if the action throws an exception, or if the
---   the 'Just'.
+--   'Maybe' is 'Nothing', otherwise returns the value in the 'Just'.
 --
 evalMaybeM :: (MonadTest m, Show a, MonadCatch m, HasCallStack) => m (Maybe a) -> m a
 evalMaybeM =

--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -76,11 +76,11 @@ module Hedgehog.Internal.Property (
   , evalNF
   , evalM
   , evalIO
-  , evalMaybe
-  , evalMaybeM
   , evalEither
   , evalEitherM
   , evalExceptT
+  , evalMaybe
+  , evalMaybeM
 
   -- * Coverage
   , Coverage(..)
@@ -824,22 +824,6 @@ evalIO :: (MonadTest m, MonadIO m, HasCallStack) => IO a -> m a
 evalIO m =
   either (withFrozenCallStack failException) pure =<< liftIO (tryAll m)
 
--- | Fails the test if the 'Maybe' is 'Nothing', otherwise returns the value in
---   the 'Just'.
---
-evalMaybe :: (MonadTest m, Show a, HasCallStack) => Maybe a -> m a
-evalMaybe = \case
-  Nothing ->
-    withFrozenCallStack $ failWith Nothing "the value was 'Nothing'"
-  Just x ->
-    pure x
-
--- | Fails the test if the 'Maybe' is 'Nothing', otherwise returns the value in
---   the 'Just'.
---
-evalMaybeM :: (MonadTest m, Show a, MonadCatch m, HasCallStack) => m (Maybe a) -> m a
-evalMaybeM = evalMaybe <=< evalM
-
 -- | Fails the test if the 'Either' is 'Left', otherwise returns the value in
 --   the 'Right'.
 --
@@ -854,7 +838,8 @@ evalEither = \case
 --   'Either' is 'Left'.  Otherwise returns the value in the 'Right'.
 --
 evalEitherM :: (MonadTest m, Show x, MonadCatch m, HasCallStack) => m (Either x a) -> m a
-evalEitherM = evalEither <=< evalM
+evalEitherM =
+  evalEither <=< evalM
 
 -- | Fails the test if the 'ExceptT' is 'Left', otherwise returns the value in
 --   the 'Right'.
@@ -862,6 +847,23 @@ evalEitherM = evalEither <=< evalM
 evalExceptT :: (MonadTest m, Show x, HasCallStack) => ExceptT x m a -> m a
 evalExceptT m =
   withFrozenCallStack evalEither =<< runExceptT m
+
+-- | Fails the test if the 'Maybe' is 'Nothing', otherwise returns the value in
+--   the 'Just'.
+--
+evalMaybe :: (MonadTest m, Show a, HasCallStack) => Maybe a -> m a
+evalMaybe = \case
+  Nothing ->
+    withFrozenCallStack $ failWith Nothing "the value was 'Nothing'"
+  Just x ->
+    pure x
+
+-- | Fails the test if the 'Maybe' is 'Nothing', otherwise returns the value in
+--   the 'Just'.
+--
+evalMaybeM :: (MonadTest m, Show a, MonadCatch m, HasCallStack) => m (Maybe a) -> m a
+evalMaybeM =
+  evalMaybe <=< evalM
 
 ------------------------------------------------------------------------
 -- PropertyT


### PR DESCRIPTION
adds:

```haskell
evalMaybe :: (MonadTest m, Show a, HasCallStack) => Maybe a -> m a
evalMaybeM :: (MonadTest m, Show a, MonadCatch m, HasCallStack) => m (Maybe a) -> m a
evalEitherM :: (MonadTest m, Show x, MonadCatch m, HasCallStack) => m (Either x a) -> m a
```

Fixes #368 