### PR TITLE
Add evalNF

### DIFF
--- a/hedgehog-example/hedgehog-example.cabal
+++ b/hedgehog-example/hedgehog-example.cabal
@@ -38,6 +38,7 @@ library
       Test.Example.Basic
     , Test.Example.Confidence
     , Test.Example.Coverage
+    , Test.Example.EvalNF
     , Test.Example.Exception
     , Test.Example.List
     , Test.Example.QuasiShow

--- a/hedgehog-example/src/Test/Example/EvalNF.hs
+++ b/hedgehog-example/src/Test/Example/EvalNF.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Test.Example.EvalNF where
+
+import           Data.Functor (void)
+
+import           Hedgehog
+
+prop_evalNF_success :: Property
+prop_evalNF_success =
+  property $
+    void $
+      evalNF [""]
+
+prop_evalNF_failure :: Property
+prop_evalNF_failure =
+  property $
+    void $
+      evalNF ["", undefined]
+
+------------------------------------------------------------------------
+
+tests :: IO Bool
+tests =
+  checkSequential $$(discover)

--- a/hedgehog-example/test/test.hs
+++ b/hedgehog-example/test/test.hs
@@ -3,6 +3,7 @@ import           System.IO (BufferMode(..), hSetBuffering, stdout, stderr)
 import qualified Test.Example.Basic
 import qualified Test.Example.Confidence
 import qualified Test.Example.Coverage
+import qualified Test.Example.EvalNF
 import qualified Test.Example.Exception
 import qualified Test.Example.QuickCheck
 import qualified Test.Example.References
@@ -20,6 +21,7 @@ main = do
       Test.Example.Basic.tests
     , Test.Example.Confidence.tests
     , Test.Example.Coverage.tests
+    , Test.Example.EvalNF.tests
     , Test.Example.Exception.tests
     , Test.Example.QuickCheck.tests
     , Test.Example.References.tests

--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -76,6 +76,7 @@ library
     , transformers                    >= 0.5        && < 0.6
     , transformers-base               >= 0.4.5.1    && < 0.5
     , wl-pprint-annotated             >= 0.0        && < 0.2
+    , deepseq                         >= 1.1.0.0    && < 1.5
 
   ghc-options:
     -Wall

--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -56,6 +56,7 @@ library
     , bytestring                      >= 0.10       && < 0.11
     , concurrent-output               >= 1.7        && < 1.11
     , containers                      >= 0.4        && < 0.7
+    , deepseq                         >= 1.1.0.0    && < 1.5
     , directory                       >= 1.2        && < 1.4
     , erf                             >= 2.0        && < 2.1
     , exceptions                      >= 0.7        && < 0.11
@@ -76,7 +77,6 @@ library
     , transformers                    >= 0.5        && < 0.6
     , transformers-base               >= 0.4.5.1    && < 0.5
     , wl-pprint-annotated             >= 0.0        && < 0.2
-    , deepseq                         >= 1.1.0.0    && < 1.5
 
   ghc-options:
     -Wall

--- a/hedgehog/src/Hedgehog.hs
+++ b/hedgehog/src/Hedgehog.hs
@@ -108,6 +108,7 @@ module Hedgehog (
   , tripping
 
   , eval
+  , evalNF
   , evalM
   , evalIO
   , evalEither
@@ -164,7 +165,7 @@ import           Hedgehog.Internal.Property (assert, diff, (===), (/==))
 import           Hedgehog.Internal.Property (classify, cover)
 import           Hedgehog.Internal.Property (discard, failure, success)
 import           Hedgehog.Internal.Property (DiscardLimit, withDiscards)
-import           Hedgehog.Internal.Property (eval, evalM, evalIO)
+import           Hedgehog.Internal.Property (eval, evalNF, evalM, evalIO)
 import           Hedgehog.Internal.Property (evalEither, evalExceptT)
 import           Hedgehog.Internal.Property (footnote, footnoteShow)
 import           Hedgehog.Internal.Property (forAll, forAllWith)

--- a/hedgehog/src/Hedgehog/Gen.hs
+++ b/hedgehog/src/Hedgehog/Gen.hs
@@ -75,6 +75,8 @@ module Hedgehog.Gen (
 
   -- ** Collections
   , maybe
+  , either
+  , either_
   , list
   , seq
   , nonEmpty
@@ -109,4 +111,4 @@ module Hedgehog.Gen (
 import           Hedgehog.Internal.Gen
 import           Hedgehog.Internal.State (sequential, parallel)
 
-import           Prelude hiding (filter, print, maybe, map, seq)
+import           Prelude hiding (either, filter, print, maybe, map, seq)

--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -705,19 +705,19 @@ failDiff x y =
 --   message.
 --
 failException :: (MonadTest m, HasCallStack) => SomeException -> m a
-failException ex =
+failException x =
   withFrozenCallStack $
-    failExceptionWith [] ex
+    failExceptionWith [] x
 
 -- | Fails with an error which renders the given messages, the type of an exception,
 --   and its error message.
 --
 failExceptionWith :: (MonadTest m, HasCallStack) => [String] -> SomeException -> m a
-failExceptionWith messages (SomeException ex) =
+failExceptionWith messages (SomeException x) =
   withFrozenCallStack
     failWith Nothing $ unlines $ messages <> [
-        "━━━ Exception (" ++ show (typeOf ex) ++ ") ━━━"
-      , List.dropWhileEnd Char.isSpace (displayException ex)
+        "━━━ Exception (" ++ show (typeOf x) ++ ") ━━━"
+      , List.dropWhileEnd Char.isSpace (displayException x)
       ]
 
 -- | Causes a test to fail.


### PR DESCRIPTION
Added `evalNF` as discussed in #383.

A couple of things:

1. I created a local `failException'`, which behaves exactly like `failException` except it also prints `━━━ Value could not be evaluated to normal form ━━━`. Alternatively, we could simply change the type of `failException` to take an additional list of lines to be printed.
    ```haskell
    -- before
    failException :: (MonadTest m, HasCallStack) => SomeException -> m a

    -- after
    failException :: (MonadTest m, HasCallStack) => [String] -> SomeException -> m a
   ```
   I suppose since `failException` is internal this would not be a breaking change, but still inconvenient... Any thoughts on whether we should refactor `failException` or leave the local bind for `failException'` in?
2. It wasn't clear to me how to add new tests for `evalNF`. I tried searching for tests for the existing `eval`, but couldn't find any. Should I add any tests and, if so, to which project/module?
3. I forgot to re-export `either` and `either_` from `Hedgehog.Gen` in my previous PR, so I did that here, if that's OK. I can also submit this is a separate PR if you'd prefer.