### PR TITLE
Bump cabal-version lower bound

### DIFF
--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -29,7 +29,7 @@ license:
 license-file:
   LICENSE
 cabal-version:
-  >= 1.8
+  >= 1.10
 build-type:
   Simple
 tested-with:
@@ -116,6 +116,9 @@ library
     Hedgehog.Internal.Tree
     Hedgehog.Internal.Tripping
 
+  default-language:
+    Haskell2010
+
 test-suite test
   type:
     exitcode-stdio-1.0
@@ -148,3 +151,6 @@ test-suite test
     , semigroups                      >= 0.16       && < 0.20
     , text                            >= 1.1        && < 1.3
     , transformers                    >= 0.3        && < 0.6
+
+  default-language:
+    Haskell2010


### PR DESCRIPTION
I'm not sure if there was an announcement for it, but it appears that Hackage now rejects packages with cabal-version lower bound less than 1.10:

```
'cabal-version' must be at least 1.10
```

And because of 1.10 it's also required to add the `default-language` field.