### PR TITLE
Clean up hedgehog.cabal for GHC 8.0+

### DIFF
--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -60,7 +60,6 @@ library
     , directory                       >= 1.2        && < 1.4
     , erf                             >= 2.0        && < 2.1
     , exceptions                      >= 0.7        && < 0.11
-    , fail                            >= 4.9        && < 5
     , lifted-async                    >= 0.7        && < 0.11
     , mmorph                          >= 1.0        && < 1.2
     , monad-control                   >= 1.0        && < 1.1
@@ -69,7 +68,6 @@ library
     , primitive                       >= 0.6        && < 0.8
     , random                          >= 1.1        && < 1.2
     , resourcet                       >= 1.1        && < 1.3
-    , semigroups                      >= 0.16       && < 0.20
     , stm                             >= 2.4        && < 2.6
     , template-haskell                >= 2.10       && < 2.17
     , text                            >= 1.1        && < 1.3
@@ -80,9 +78,6 @@ library
 
   ghc-options:
     -Wall
-
-  if impl(ghc >= 8.0)
-    ghc-options: -Wnoncanonical-monad-instances
 
   hs-source-dirs:
     src
@@ -148,7 +143,6 @@ test-suite test
     , mmorph                          >= 1.0        && < 1.2
     , mtl                             >= 2.1        && < 2.3
     , pretty-show                     >= 1.6        && < 1.11
-    , semigroups                      >= 0.16       && < 0.20
     , text                            >= 1.1        && < 1.3
     , transformers                    >= 0.3        && < 0.6
 


### PR DESCRIPTION
Since we have dropped support for GHC 7.10, the redundant packages `fail` and `semigroups` can be removed now. The additional warning is also included in `-Wall`.