### PR TITLE
GHC 9 Support

### DIFF
--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -71,7 +71,7 @@ library
     , resourcet                       >= 1.1        && < 1.3
     , semigroups                      >= 0.16       && < 0.20
     , stm                             >= 2.4        && < 2.6
-    , template-haskell                >= 2.10       && < 2.17
+    , template-haskell                >= 2.10       && < 2.18
     , text                            >= 1.1        && < 1.3
     , time                            >= 1.4        && < 1.10
     , transformers                    >= 0.5        && < 0.6

--- a/hedgehog/src/Hedgehog/Internal/Distributive.hs
+++ b/hedgehog/src/Hedgehog/Internal/Distributive.hs
@@ -22,6 +22,7 @@ import qualified Control.Monad.Trans.State.Strict as Strict
 import qualified Control.Monad.Trans.Writer.Lazy as Lazy
 import qualified Control.Monad.Trans.Writer.Strict as Strict
 
+import           Data.Kind (Type)
 import           GHC.Exts (Constraint)
 
 ------------------------------------------------------------------------
@@ -29,9 +30,9 @@ import           GHC.Exts (Constraint)
 
 class MonadTransDistributive g where
   type Transformer
-    (f :: (* -> *) -> * -> *)
-    (g :: (* -> *) -> * -> *)
-    (m :: * -> *) :: Constraint
+    (f :: (Type -> Type) -> Type -> Type)
+    (g :: (Type -> Type) -> Type -> Type)
+    (m :: Type -> Type) :: Constraint
 
   type Transformer f g m = (
       Monad m

--- a/hedgehog/src/Hedgehog/Internal/Gen.hs
+++ b/hedgehog/src/Hedgehog/Internal/Gen.hs
@@ -204,6 +204,7 @@ import qualified Data.Char as Char
 import           Data.Foldable (for_, toList)
 import           Data.Functor.Identity (Identity(..))
 import           Data.Int (Int8, Int16, Int32, Int64)
+import           Data.Kind (Type)
 import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NonEmpty
 import           Data.Map (Map)
@@ -350,7 +351,7 @@ generalize =
 -- | Class of monads which can generate input data for tests.
 --
 class (Monad m, Monad (GenBase m)) => MonadGen m where
-  type GenBase m :: (* -> *)
+  type GenBase m :: (Type -> Type)
 
   -- | Extract a 'GenT' from a  'MonadGen'.
   --

--- a/hedgehog/src/Hedgehog/Internal/State.hs
+++ b/hedgehog/src/Hedgehog/Internal/State.hs
@@ -65,6 +65,7 @@ import           Data.Dynamic (Dynamic, toDyn, fromDynamic, dynTypeRep)
 import           Data.Foldable (traverse_)
 import           Data.Functor.Classes (Eq1(..), Ord1(..), Show1(..))
 import           Data.Functor.Classes (eq1, compare1, showsPrec1)
+import           Data.Kind (Type)
 import           Data.Map (Map)
 import qualified Data.Map as Map
 import qualified Data.Maybe as Maybe
@@ -374,7 +375,7 @@ callbackEnsure callbacks s0 s i o =
 -- an instance of 'MonadTest'. These constraints appear when you pass
 -- your 'Command' list to 'sequential' or 'parallel'.
 --
-data Command gen m (state :: (* -> *) -> *) =
+data Command gen m (state :: (Type -> Type) -> Type) =
   forall input output.
   (HTraversable input, Show (input Symbolic), Show output, Typeable output) =>
   Command {
@@ -406,7 +407,7 @@ commandGenOK (Command inputGen _ _) state =
 -- | An instantiation of a 'Command' which can be executed, and its effect
 --   evaluated.
 --
-data Action m (state :: (* -> *) -> *) =
+data Action m (state :: (Type -> Type) -> Type) =
   forall input output.
   (HTraversable input, Show (input Symbolic), Show output) =>
   Action {


### PR DESCRIPTION
This PR makes Hedgehog compile with the current GHC development branch (soon to be GHC 9). It only required two minor changes on hedgehog side:

* Use `Data.Kind.Type` instead of `*`
* Supporting template-haskell 2.17

See the commit messages for a bit more details.

These changes should be enough from the hedgehog side, but even after these:

* `--allow-newer` flag has to be passed since `primitive` has an overly restrictive upper bound on `base`.
* `QuickCheck` does not compile [yet](https://github.com/nick8325/quickcheck/pull/311), so `hedgehog-quickcheck` does not work yet.

I tried to keep the changes as small as possible while maintaining the backwards compatibility, however I did only check with GHC 8.10 and GHC 9. Let me know if there is anything else I should do to get it compatible with even older GHC versions.