### PR TITLE
Use Integer in towards for halving during shrinking

### DIFF
--- a/hedgehog/src/Hedgehog/Internal/Shrink.hs
+++ b/hedgehog/src/Hedgehog/Internal/Shrink.hs
@@ -27,13 +27,17 @@ towards :: Integral a => a -> a -> [a]
 towards destination x =
   if destination == x then
     []
+  -- special case for 1-bit numbers
+  else if destination == 0 && x == 1 then
+    [0]
   else
     let
       -- Halve the operands before subtracting them so they don't overflow.
       -- Consider 'minBound' and 'maxBound' for a fixed sized type like 'Int64'.
-      diff = (toInteger x `quot` 2) - (toInteger destination `quot` 2)
+      diff =
+        (x `quot` 2) - (destination `quot` 2)
     in
-      destination `consNub` fmap ((x -) . fromInteger) (halves diff)
+      destination `consNub` fmap (x -) (halves diff)
 
 -- | Shrink a floating-point number by edging towards a destination.
 --

--- a/hedgehog/src/Hedgehog/Internal/Shrink.hs
+++ b/hedgehog/src/Hedgehog/Internal/Shrink.hs
@@ -31,10 +31,9 @@ towards destination x =
     let
       -- Halve the operands before subtracting them so they don't overflow.
       -- Consider 'minBound' and 'maxBound' for a fixed sized type like 'Int64'.
-      diff =
-        (x `quot` 2) - (destination `quot` 2)
+      diff = (toInteger x `quot` 2) - (toInteger destination `quot` 2)
     in
-      destination `consNub` fmap (x -) (halves diff)
+      destination `consNub` fmap ((x -) . fromInteger) (halves diff)
 
 -- | Shrink a floating-point number by edging towards a destination.
 --


### PR DESCRIPTION
This fixes the odd situation in which 2 is not representable as a number in a type. In particular this occurs in the package 'clash-prelude', which defines types such as `Unsigned 1` where only 0 and 1 can be represented.

This is in a sense more of an issue with `clash` types not having fully valid `Num` instances, however it is very easy to fix here and having an error during shrinking is very difficult to debug!