### PR TITLE
Improve the distribution of `scaleLinear`

### DIFF
--- a/hedgehog/src/Hedgehog/Internal/Range.hs
+++ b/hedgehog/src/Hedgehog/Internal/Range.hs
@@ -307,8 +307,9 @@ scaleLinear sz0 z0 n0 =
 
     -- @rng@ has magnitude 1 bigger than the biggest diff
     -- i.e. it specifies the range the diff can be in [0,rng)
-    -- with the upper bound being exclusive
-    rng = n - z + signum (n - z)
+    -- with the upper bound being exclusive.
+    rng =
+      n - z + signum (n - z)
 
     diff =
       (rng * fromIntegral sz) `quot` 100

--- a/hedgehog/src/Hedgehog/Internal/Range.hs
+++ b/hedgehog/src/Hedgehog/Internal/Range.hs
@@ -305,8 +305,13 @@ scaleLinear sz0 z0 n0 =
     n =
       toInteger n0
 
+    -- @rng@ has magnitude 1 bigger than the biggest diff
+    -- i.e. it specifies the range the diff can be in [0,rng)
+    -- with the upper bound being exclusive
+    rng = n - z + signum (n - z)
+
     diff =
-      ((n - z) * fromIntegral sz) `quot` 99
+      (rng * fromIntegral sz) `quot` 100
   in
     fromInteger $ z + diff
 


### PR DESCRIPTION
`scaleLinear` currently only allows the largest value to be generated when at the maximum size `99`:
```
> fmap (\sz -> scaleLinea sz 0 4) [0..99] :: [Integer]
[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,2,2
,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,4]
```
This improves the distribution so each value is the `max` for an equal number of sizes:
```
> fmap (\sz -> scaleLinear sz 0 4) [0..99] :: [Integer]
[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,2,2,2,2,2,2,2,2,2,2,2,2
,2,2,2,2,2,2,2,2,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4]
```
