### PR TITLE
Change frequency generator to immediately shrink

### DIFF
--- a/hedgehog/src/Hedgehog/Internal/Gen.hs
+++ b/hedgehog/src/Hedgehog/Internal/Gen.hs
@@ -1190,10 +1190,13 @@ frequency = \case
           else
             pick (n - k) xs
 
+      iis =
+        scanl1 (+) (fmap fst xs0)
+
       total =
         sum (fmap fst xs0)
 
-    n <- integral $ Range.constant 1 total
+    n <- shrink (\n -> takeWhile (< n) iis) $ integral_ $ Range.constant 1 total
     pick n xs0
 
 -- | Modifies combinators which choose from a list of generators, like 'choice'


### PR DESCRIPTION
Change frequency generator immediately shrink

The frequency generators works by totalling all weights, and then
picking a random number between [0, total]. It then selects the first
generator who's cummulative weight matches this number. This works fine,
but the current implementation leads to poor shrinking behavior. In
particular, the shrinking is driven by repeatedly picking smaller
numbers in the range [0, total]. For skewed distributions, this can mean
repeatedly reselecting the same generator.

This commit makes the observation that the weight only matters for the
first pick. Once you have made a choice and observed a test failure, you
can give all generators equal weight, as we're going to perform a
breadth-first enumeration to try and find a shrink anyway.

Before this patch, we would see behavior like:

```
> printWith 30 (Seed 4 1) $ Hedgehog.Gen.maybe alphaNum
=== Outcome ===
Just 'o'
=== Shrinks ===
Nothing
Just 'o'
Just 'o'
Just 'o'
Just 'o'
Just 'a'
Just 'h'
Just 'l'
Just 'n'
```

Note that `Just 'o'` appears many times - this is because the maybe
generator puts a heavy bias towards 'Just' constructors.

With this commit, we get the much more minimal output:

```
> printWith 30 (Seed 4 1) $ Hedgehog.Gen.maybe alphaNum
=== Outcome ===
Just 'o'
=== Shrinks ===
Nothing
Just 'a'
Just 'h'
Just 'l'
Just 'n'
```

Note that no characters were duplicated.