### PR TITLE
Allow bytestring-0.11

### DIFF
--- a/hedgehog-dieharder/hedgehog-dieharder.cabal
+++ b/hedgehog-dieharder/hedgehog-dieharder.cabal
@@ -45,4 +45,4 @@ executable dieharder-input
   build-depends:
       hedgehog
     , base                            >= 3          && < 5
-    , bytestring                      >= 0.10.4.0   && < 0.11
+    , bytestring                      >= 0.10.4.0   && < 0.12

--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -53,7 +53,7 @@ library
       base                            >= 4.9        && < 5
     , ansi-terminal                   >= 0.6        && < 0.12
     , async                           >= 2.0        && < 2.3
-    , bytestring                      >= 0.10       && < 0.11
+    , bytestring                      >= 0.10       && < 0.12
     , concurrent-output               >= 1.7        && < 1.11
     , containers                      >= 0.4        && < 0.7
     , deepseq                         >= 1.1.0.0    && < 1.5


### PR DESCRIPTION
Tested with the following config:
```
packages:
  hedgehog
  hedgehog-corpus
  hedgehog-dieharder
  hedgehog-example
  hedgehog-quickcheck
  hedgehog-test-laws

-- would like to do this but cabal applies it to
-- _all_ packages not just local :wtf:
--    https://github.com/haskell/cabal/issues/3883
-- program-options
--   ghc-options: -Wall -Werror

package hedgehog
  ghc-options: -Wall -Werror
package hedgehog-corpus
  ghc-options: -Wall -Werror
package hedgehog-dieharder
  ghc-options: -Wall -Werror
package hedgehog-example
  ghc-options: -Wall -Werror
package hedgehog-quickcheck
  ghc-options: -Wall -Werror
package hedgehog-test-laws
  ghc-options: -Wall -Werror

tests: True

constraints:
  bytestring >= 0.11

allow-newer:
  -- https://github.com/tibbe/hashable/pull/191
  hashable:bytestring,
  -- https://github.com/haskell/parsec/pull/116
  parsec:bytestring

source-repository-package
  type: git
  location: https://github.com/haskell/text
  tag: v1.2.4.1-rc1
```