### PR TITLE
Generalise Hedgehog.Gen.element

### DIFF
--- a/hedgehog/src/Hedgehog/Internal/Gen.hs
+++ b/hedgehog/src/Hedgehog/Internal/Gen.hs
@@ -1149,7 +1149,7 @@ constant =
 element :: (Foldable f, MonadGen m) => f a -> m a
 element fa = case toList fa of
   [] ->
-    error "Hedgehog.Gen.element: used with empty list"
+    error "Hedgehog.Gen.element: used with empty Foldable"
   xs -> do
     n <- integral $ Range.constant 0 (length xs - 1)
     pure $ xs !! n

--- a/hedgehog/src/Hedgehog/Internal/Gen.hs
+++ b/hedgehog/src/Hedgehog/Internal/Gen.hs
@@ -1152,7 +1152,7 @@ element = \case
     error "Hedgehog.Gen.element: used with empty list"
   xs -> do
     n <- integral $ Range.constant 0 (length xs - 1)
-    pure $ xs !! toList n
+    pure $ toList xs !! n
 
 -- | Randomly selects one of the generators in the list.
 --

--- a/hedgehog/src/Hedgehog/Internal/Gen.hs
+++ b/hedgehog/src/Hedgehog/Internal/Gen.hs
@@ -1147,12 +1147,12 @@ constant =
 --   /The input list must be non-empty./
 --
 element :: (Foldable f, MonadGen m) => f a -> m a
-element = \case
+element fa = case toList fa of
   [] ->
     error "Hedgehog.Gen.element: used with empty list"
   xs -> do
     n <- integral $ Range.constant 0 (length xs - 1)
-    pure $ toList xs !! n
+    pure $ xs !! n
 
 -- | Randomly selects one of the generators in the list.
 --

--- a/hedgehog/src/Hedgehog/Internal/Gen.hs
+++ b/hedgehog/src/Hedgehog/Internal/Gen.hs
@@ -1146,13 +1146,13 @@ constant =
 --
 --   /The input list must be non-empty./
 --
-element :: MonadGen m => [a] -> m a
+element :: (Foldable f, MonadGen m) => f a -> m a
 element = \case
   [] ->
     error "Hedgehog.Gen.element: used with empty list"
   xs -> do
     n <- integral $ Range.constant 0 (length xs - 1)
-    pure $ xs !! n
+    pure $ xs !! toList n
 
 -- | Randomly selects one of the generators in the list.
 --


### PR DESCRIPTION
Having this only work on lists is more restrictive than it needs to be. This commit generalizes `element` to instead work on any `Foldable`.