### PR TITLE
Use binary shrinking for integral.

### DIFF
--- a/hedgehog/src/Hedgehog/Internal/Gen.hs
+++ b/hedgehog/src/Hedgehog/Internal/Gen.hs
@@ -802,8 +802,8 @@ golden x =
 integral :: forall m a. (MonadGen m, Integral a) => Range a -> m a
 integral range =
   let
-    appendOrigin :: Tree.TreeT (MaybeT (GenBase m)) a -> Tree.TreeT (MaybeT (GenBase m)) a
-    appendOrigin tree =
+    tryOriginFirst :: Tree.TreeT (MaybeT (GenBase m)) a -> Tree.TreeT (MaybeT (GenBase m)) a
+    tryOriginFirst tree =
       Tree.TreeT $ do
         let origin_ = Range.origin range
         Tree.NodeT x xs <- Tree.runTreeT tree
@@ -831,7 +831,7 @@ integral range =
     withGenT' = withGenT
 
   in
-    withGenT' (mapGenT (binarySearchTree (Range.origin range) . appendOrigin)) (integral_ range)
+    withGenT' (mapGenT (tryOriginFirst . binarySearchTree (Range.origin range))) (integral_ range)
 
 -- | Generates a random integral number in the [inclusive,inclusive] range.
 --

--- a/hedgehog/src/Hedgehog/Internal/Gen.hs
+++ b/hedgehog/src/Hedgehog/Internal/Gen.hs
@@ -801,6 +801,7 @@ golden x =
 --
 integral :: forall m a. (MonadGen m, Integral a) => Range a -> m a
 integral range =
+  -- https://github.com/hedgehogqa/haskell-hedgehog/pull/413/files
   let
     tryOriginFirst :: Tree.TreeT (MaybeT (GenBase m)) a -> Tree.TreeT (MaybeT (GenBase m)) a
     tryOriginFirst tree =

--- a/hedgehog/src/Hedgehog/Internal/Gen.hs
+++ b/hedgehog/src/Hedgehog/Internal/Gen.hs
@@ -805,10 +805,13 @@ integral range =
     appendOrigin :: Tree.TreeT (MaybeT (GenBase m)) a -> Tree.TreeT (MaybeT (GenBase m)) a
     appendOrigin tree =
       Tree.TreeT $ do
+        let origin_ = Range.origin range
         Tree.NodeT x xs <- Tree.runTreeT tree
         pure $
-          Tree.NodeT x $
-            xs <> [pure (Range.origin range)]
+          if x == origin_ then
+            Tree.NodeT x xs
+          else
+            Tree.NodeT x (pure origin_ : xs)
 
     binarySearchTree :: a -> Tree.TreeT (MaybeT (GenBase m)) a -> Tree.TreeT (MaybeT (GenBase m)) a
     binarySearchTree bottom tree =


### PR DESCRIPTION
The current shrink strategy produces potentially quite a lot of
duplication. By using a binary search, we should be able to
significantly speed up shrinking.

With this change we can see

```
Gen.printTreeWith  30 (Seed 5 3)  $ Gen.int (Range.constant 0 22)
 7
 ├╼ 0
 ├╼ 4
 │  ├╼ 2
 │  │  └╼ 1
 │  └╼ 3
 └╼ 6
    └╼ 5
```

While before we had
```
Gen.printTreeWith  30 (Seed 5 3)  $ Gen.int (Range.constant 0 22)
 7
 ├╼ 0
 ├╼ 4
 │  ├╼ 0
 │  ├╼ 2
 │  │  ├╼ 0
 │  │  └╼ 1
 │  │     └╼ 0
 │  └╼ 3
 │     ├╼ 0
 │     └╼ 2
 │        ├╼ 0
 │        └╼ 1
 │           └╼ 0
 └╼ 6
    ├╼ 0
    ├╼ 3
    │  ├╼ 0
    │  └╼ 2
    │     ├╼ 0
    │     └╼ 1
    │        └╼ 0
    └╼ 5
       ├╼ 0
       ├╼ 3
       │  ├╼ 0
       │  └╼ 2
       │     ├╼ 0
       │     └╼ 1
       │        └╼ 0
       └╼ 4
          ├╼ 0
          ├╼ 2
          │  ├╼ 0
          │  └╼ 1
          │     └╼ 0
          └╼ 3
             ├╼ 0
             └╼ 2
                ├╼ 0
                └╼ 1
                   └╼ 0
```

The first level of the tree is exactly the same, but then the size of the
tree reduces significantly as all duplication is removed.

This is currently just for `integral`, but as integral is used for
`element`, this should improve things pretty broadly.