### PR TITLE
Build tree from values instead of wrapping and unwrapping

### DIFF
--- a/hedgehog/src/Hedgehog/Internal/Tree.hs
+++ b/hedgehog/src/Hedgehog/Internal/Tree.hs
@@ -40,6 +40,7 @@ module Hedgehog.Internal.Tree (
   , filterMaybeT
   , mapMaybeMaybeT
   , filterT
+  , consChild
   , mapMaybeT
   , depth
   , interleave
@@ -315,6 +316,14 @@ mapMaybeT p m =
           NodeT x' (fmap (mapMaybeT p) xs)
       Nothing ->
         empty
+
+consChild :: (Monad m) => a -> TreeT m a -> TreeT m a
+consChild a m =
+  TreeT $ do
+    NodeT x xs <- runTreeT m
+    pure $
+      NodeT x $
+        pure a : xs
 
 ------------------------------------------------------------------------
 


### PR DESCRIPTION
This is just a minor cleanup, there should be no function differences.

As I mentioned earlier, my original version wrapped and unwrapped trees a bit much, making the code a bit harder to follow.

Pulling out a helper for `integral_` means we can build on values only.