### PR TITLE
Don't shrink the action chosen in state machine testing

### DIFF
--- a/hedgehog/src/Hedgehog/Internal/Gen.hs
+++ b/hedgehog/src/Hedgehog/Internal/Gen.hs
@@ -93,6 +93,7 @@ module Hedgehog.Internal.Gen (
   -- ** Choice
   , constant
   , element
+  , element_
   , choice
   , frequency
   , recursive
@@ -1184,6 +1185,20 @@ element = \case
     error "Hedgehog.Gen.element: used with empty list"
   xs -> do
     n <- integral $ Range.constant 0 (length xs - 1)
+    pure $ xs !! n
+
+-- | Randomly selects one of the elements in the list.
+--
+--   This generator does not shrink the choice of element.
+--
+--   /The input list must be non-empty./
+--
+element_ :: MonadGen m => [a] -> m a
+element_ = \case
+  [] ->
+    error "Hedgehog.Gen.element: used with empty list"
+  xs -> do
+    n <- integral_ $ Range.constant 0 (length xs - 1)
     pure $ xs !! n
 
 -- | Randomly selects one of the generators in the list.

--- a/hedgehog/src/Hedgehog/Internal/State.hs
+++ b/hedgehog/src/Hedgehog/Internal/State.hs
@@ -542,7 +542,7 @@ action commands =
     Context state0 _ <- get
 
     Command mgenInput exec callbacks <-
-      Gen.element $ filter (\c -> commandGenOK c state0) commands
+      Gen.element_ $ filter (\c -> commandGenOK c state0) commands
 
     input <-
       case mgenInput state0 of
@@ -579,7 +579,7 @@ genActions range commands ctx = do
 
 -- | A sequence of actions to execute.
 --
-data Sequential m state =
+newtype Sequential m state =
   Sequential {
       -- | The sequence of actions.
       sequentialActions :: [Action m state]


### PR DESCRIPTION
While the contents of the action is fair game for shrinking, as is the sequence of actions, it makes little sense to change an action which may be the one which causes the error.
