### PR TITLE
Redefine MonadFail Gen to call discard

### DIFF
--- a/hedgehog/src/Hedgehog/Internal/Gen.hs
+++ b/hedgehog/src/Hedgehog/Internal/Gen.hs
@@ -529,7 +529,7 @@ instance Monad m => Monad (GenT m) where
 
 instance Monad m => MonadFail (GenT m) where
   fail =
-    error
+    discard
 
 instance Monad m => Alternative (GenT m) where
   empty =


### PR DESCRIPTION
I find it very counterintuitive that we can't have failing pattern matches act like `discard` when generating values. 

To provide an example of where this is useful, I'm trying to generate trees of well typed terms. Some types have a rich structure that lets me learn about more type class constrains. In my list of alternatives, I would like to write:

```haskell
        union = do
          Just Dict <- return (isEqTable t)
          Union <$> genQuery t <*> genQuery t 
```

But I can't do this, because if `isEqTable` returns `Nothing` this whole generator just calls `error`, rather than not considering this alternative. Instead, I have to write

```haskell
          Dict <- just $ pure $ isEqTable t
          Union <$> genQuery t <*> genQuery t 
```

which I find a little more clunky (and this doesn't scale to other patterns).