### PR TITLE
Add better TraversableB documentation including deprecation warning for HTraversable

### DIFF
--- a/hedgehog-example/src/Test/Example/Registry.hs
+++ b/hedgehog-example/src/Test/Example/Registry.hs
@@ -23,7 +23,6 @@ import qualified Data.Set as Set
 
 import           Hedgehog
 import qualified Hedgehog.Gen as Gen
-import qualified Hedgehog.Internal.State as Gen
 import qualified Hedgehog.Range as Range
 
 import           System.IO.Unsafe (unsafePerformIO)
@@ -72,10 +71,15 @@ data Spawn (v :: * -> *) =
   Spawn
   deriving (Eq, Show, Generic)
 
--- This would be more nicely done with DerivingStrategies anyclass but
+-- This can also be done with DerivingStrategies/DeriveAnyClass but
 -- it's not supported in GHC 8.0, in your own app you have more options.
 instance FunctorB Spawn
 instance TraversableB Spawn
+
+-- Uncomment to check deprecation warning.
+--instance HTraversable Spawn where
+--  htraverse _ Spawn =
+--    pure Spawn
 
 spawn :: (Monad n, MonadIO m) => Command n m State
 spawn =
@@ -261,7 +265,7 @@ prop_registry_sequential =
         [spawn, register, unregister]
 
     evalIO ioReset
-    Gen.executeSequential initialState actions
+    executeSequential initialState actions
 
 prop_registry_parallel :: Property
 prop_registry_parallel =
@@ -275,7 +279,7 @@ prop_registry_parallel =
 
     test $ do
       evalIO ioReset
-      Gen.executeParallel initialState actions
+      executeParallel initialState actions
 
 ------------------------------------------------------------------------
 

--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -95,6 +95,7 @@ library
     Hedgehog.Internal.Distributive
     Hedgehog.Internal.Exception
     Hedgehog.Internal.Gen
+    Hedgehog.Internal.HTraversable
     Hedgehog.Internal.Opaque
     Hedgehog.Internal.Prelude
     Hedgehog.Internal.Property

--- a/hedgehog/src/Hedgehog.hs
+++ b/hedgehog/src/Hedgehog.hs
@@ -145,6 +145,7 @@ module Hedgehog (
   , distributeT
 
   -- * Functors
+  -- $functors
   , FunctorB(..)
   , TraversableB(..)
   , Rec(..)
@@ -157,6 +158,9 @@ module Hedgehog (
 
   , Show1
   , showsPrec1
+
+  -- * Deprecated
+  , HTraversable(..)
   ) where
 
 import           Data.Functor.Classes (Eq1, eq1, Ord1, compare1, Show1, showsPrec1)
@@ -164,6 +168,7 @@ import           Data.Functor.Classes (Eq1, eq1, Ord1, compare1, Show1, showsPre
 import           Hedgehog.Internal.Barbie (FunctorB(..), TraversableB(..), Rec(..))
 import           Hedgehog.Internal.Distributive (distributeT)
 import           Hedgehog.Internal.Gen (Gen, GenT, MonadGen(..))
+import           Hedgehog.Internal.HTraversable (HTraversable(..))
 import           Hedgehog.Internal.Opaque (Opaque(..))
 import           Hedgehog.Internal.Property (annotate, annotateShow)
 import           Hedgehog.Internal.Property (assert, diff, (===), (/==))
@@ -192,3 +197,22 @@ import           Hedgehog.Internal.State (executeSequential, executeParallel)
 import           Hedgehog.Internal.State (Var(..), Symbolic, Concrete(..), concrete, opaque)
 import           Hedgehog.Internal.TH (discover, discoverPrefix)
 import           Hedgehog.Internal.Tripping (tripping)
+
+
+-- $functors
+--
+-- 'FunctorB' and 'TraversableB' must be implemented for all 'Command' @input@ types.
+--
+-- This is most easily achieved using "GHC.Generics".
+--
+-- @
+-- data Register v =
+--   Register Name (Var Pid v)
+--   deriving (Eq, Show, Generic)
+--
+-- instance FunctorB Register
+-- instance TraversableB Register
+-- @
+--
+-- /Ideally we could use @DerivingVia@ instead of @DefaultSignatures@, patches welcome./
+--

--- a/hedgehog/src/Hedgehog.hs
+++ b/hedgehog/src/Hedgehog.hs
@@ -203,7 +203,7 @@ import           Hedgehog.Internal.Tripping (tripping)
 --
 -- 'FunctorB' and 'TraversableB' must be implemented for all 'Command' @input@ types.
 --
--- This is most easily achieved using "GHC.Generics".
+-- This is most easily achieved using `DeriveGeneric`:
 --
 -- @
 -- data Register v =
@@ -212,7 +212,25 @@ import           Hedgehog.Internal.Tripping (tripping)
 --
 -- instance FunctorB Register
 -- instance TraversableB Register
+--
+-- newtype Unregister (v :: * -> *) =
+--   Unregister Name
+--   deriving (Eq, Show, Generic)
+--
+-- instance FunctorB Unregister
+-- instance TraversableB Unregister
 -- @
 --
--- /Ideally we could use @DerivingVia@ instead of @DefaultSignatures@, patches welcome./
+-- `DeriveAnyClass` and `DerivingStrategies` allow a more compact syntax:
+--
+-- @
+-- data Register v =
+--   Register Name (Var Pid v)
+--   deriving (Eq, Show, Generic, FunctorB, TraversableB)
+--
+-- newtype Unregister (v :: * -> *) =
+--   Unregister Name
+--   deriving (Eq, Show, Generic)
+--   deriving anyclass (FunctorB, TraversableB)
+-- @
 --

--- a/hedgehog/src/Hedgehog/Internal/Barbie.hs
+++ b/hedgehog/src/Hedgehog/Internal/Barbie.hs
@@ -1,7 +1,7 @@
 {-# OPTIONS_HADDOCK not-home #-}
 {-# LANGUAGE CPP #-}
 
--- | For compatibility across different barbie versions.
+-- | For compatibility across different versions of the @barbie@ package.
 --
 module Hedgehog.Internal.Barbie (
     FunctorB(..)

--- a/hedgehog/src/Hedgehog/Internal/HTraversable.hs
+++ b/hedgehog/src/Hedgehog/Internal/HTraversable.hs
@@ -1,0 +1,20 @@
+{-# OPTIONS_HADDOCK not-home #-}
+{-# OPTIONS_GHC -fno-warn-unused-imports #-}
+{-# LANGUAGE RankNTypes #-}
+module Hedgehog.Internal.HTraversable (
+    HTraversable(..)
+  ) where
+
+import Hedgehog.Internal.Barbie (TraversableB)
+
+-- | Higher-order traversable functors.
+--
+-- /Deprecated in favor of 'TraversableB' which can be derived using "GHC.Generics"/
+--
+class HTraversable t where
+  htraverse :: Applicative f => (forall a. g a -> f (h a)) -> t g -> f (t h)
+
+{-#
+  DEPRECATED HTraversable
+  "Replace with Hedgehog.TraversableB (defined in Data.Functor.Barbie) which can be derived automatically using GHC.Generics"
+#-}


### PR DESCRIPTION
Added an example showing how to derive `TraversableB` and a warning if you try to use `HTraversable`.

Hopefully that makes the upgrade process a bit easier.

Any suggestions welcome.