### PR TITLE
Support shrinking with hedgehog generators in QuickCheck

### DIFF
--- a/hedgehog-quickcheck/src/Test/QuickCheck/Hedgehog.hs
+++ b/hedgehog-quickcheck/src/Test/QuickCheck/Hedgehog.hs
@@ -25,9 +25,9 @@ genSeed =
 
 -- | Create a QuickCheck 'QuickCheck.Gen' from a Hedgehog 'Gen'.
 --
---   /Note that this conversion does not preserve shrinking. To preserve
---    shrinking use the exported 'forAll' and 'forAllShow' functions rather
---    than going via a 'QuickCheck.Gen'./
+--   /Note that this conversion does not preserve shrinking. To preserve/
+--   /shrinking use the exported 'forAll' and 'forAllShow' functions rather/
+--   /than going via a 'QuickCheck.Gen'./
 --
 hedgehog :: Gen a -> QuickCheck.Gen a
 hedgehog gen =

--- a/hedgehog-quickcheck/src/Test/QuickCheck/Hedgehog.hs
+++ b/hedgehog-quickcheck/src/Test/QuickCheck/Hedgehog.hs
@@ -3,8 +3,8 @@
 module Test.QuickCheck.Hedgehog (
     hedgehog
 
-  , forAll
-  , forAllShow
+  , forAllH
+  , forAllHShow
   ) where
 
 import           Hedgehog (Gen, Seed)
@@ -26,7 +26,7 @@ genSeed =
 -- | Create a QuickCheck 'QuickCheck.Gen' from a Hedgehog 'Gen'.
 --
 --   /Note that this conversion does not preserve shrinking. To preserve/
---   /shrinking use the exported 'forAll' and 'forAllShow' functions rather/
+--   /shrinking use the exported 'forAllH' and 'forAllHShow' functions rather/
 --   /than going via a 'QuickCheck.Gen'./
 --
 hedgehog :: Gen a -> QuickCheck.Gen a
@@ -51,17 +51,17 @@ hedgehog gen =
 --   show typeclass for displaying errors.
 --
 --   This operation preserves Hedgehog's shrinking capabilities.
-forAll :: (Show a, Testable prop) => Gen a -> (a -> prop) -> QuickCheck.Property
-forAll =
-  forAllShow showPretty
+forAllH :: (Show a, Testable prop) => Gen a -> (a -> prop) -> QuickCheck.Property
+forAllH =
+  forAllHShow showPretty
 
 
 -- | Use a Hedgehog 'Gen' in a QuickCheck 'QuickCheck.Property', but provide a custom render function
 --   for displaying counterexamples.
 --
 --   This operation preserves Hedgehog's shrinking capabilities.
-forAllShow :: Testable prop => (a -> String) -> Gen a -> (a -> prop) -> QuickCheck.Property
-forAllShow render gen pf =
+forAllHShow :: Testable prop => (a -> String) -> Gen a -> (a -> prop) -> QuickCheck.Property
+forAllHShow render gen pf =
   QuickCheck.again $
     MkProperty $
       let
@@ -89,7 +89,7 @@ shrinking tree pf =
     props x =
       MkRose
         (unProperty . QuickCheck.property . pf $ treeValue x)
-        (fmap props $ treeChildren x)
+        (props <$> treeChildren x)
   in
-    fmap (MkProp . joinRose . fmap unProp) $
+    MkProp . joinRose . fmap unProp <$>
       promote (props tree)

--- a/hedgehog-quickcheck/src/Test/QuickCheck/Hedgehog.hs
+++ b/hedgehog-quickcheck/src/Test/QuickCheck/Hedgehog.hs
@@ -2,15 +2,22 @@
 --
 module Test.QuickCheck.Hedgehog (
     hedgehog
+
+  , forAll
+  , forAllShow
   ) where
 
-import           Hedgehog
+import           Hedgehog (Gen, Seed)
+import           Hedgehog.Internal.Show (showPretty)
 import           Hedgehog.Internal.Gen (evalGen)
 import qualified Hedgehog.Internal.Seed as Seed
-import           Hedgehog.Internal.Tree (treeValue)
+import           Hedgehog.Internal.Tree (Tree, treeValue, treeChildren)
 
 import qualified Test.QuickCheck as QuickCheck
 
+import           Test.QuickCheck.Gen.Unsafe (promote)
+import           Test.QuickCheck.Property (Testable(..), Property(..), Prop(..), Rose(..))
+import           Test.QuickCheck.Property (joinRose, counterexample)
 
 genSeed :: QuickCheck.Gen Seed
 genSeed =
@@ -18,8 +25,9 @@ genSeed =
 
 -- | Create a QuickCheck 'QuickCheck.Gen' from a Hedgehog 'Gen'.
 --
---   /Note that this conversion does not preserve shrinking. There is currently/
---   /no way to use Hedgehog's shrinking capability inside QuickCheck./
+--   /Note that this conversion does not preserve shrinking. To preserve
+--    shrinking use the exported 'forAll' and 'forAllShow' functions rather
+--    than going via a 'QuickCheck.Gen'./
 --
 hedgehog :: Gen a -> QuickCheck.Gen a
 hedgehog gen =
@@ -37,3 +45,51 @@ hedgehog gen =
             pure $ treeValue x
   in
     loop (100 :: Int)
+
+
+-- | Use a Hedgehog 'Gen' in a QuickCheck 'QuickCheck.Property', using the
+--   show typeclass for displaying errors.
+--
+--   This operation preserves Hedgehog's shrinking capabilities.
+forAll :: (Show a, Testable prop) => Gen a -> (a -> prop) -> QuickCheck.Property
+forAll =
+  forAllShow showPretty
+
+
+-- | Use a Hedgehog 'Gen' in a QuickCheck 'QuickCheck.Property', but provide a custom render function
+--   for displaying counterexamples.
+--
+--   This operation preserves Hedgehog's shrinking capabilities.
+forAllShow :: Testable prop => (a -> String) -> Gen a -> (a -> prop) -> QuickCheck.Property
+forAllShow render gen pf =
+  QuickCheck.again $
+    MkProperty $
+      let
+        loop n =
+          if n <= 0 then
+            QuickCheck.discard
+          else do
+            seed <- genSeed
+            size <- QuickCheck.sized (pure . fromIntegral)
+            case evalGen size seed gen of
+              Nothing ->
+                loop (n - 1)
+              Just tree ->
+                shrinking tree $ \x ->
+                  counterexample (render x) $
+                  pf x
+
+      in
+        loop (100 :: Int)
+
+-- | Use an existing 'Tree' to exercise a given property.
+shrinking :: Testable prop => Tree a -> (a -> prop) -> QuickCheck.Gen Prop
+shrinking tree pf =
+  let
+    props x =
+      MkRose
+        (unProperty . QuickCheck.property . pf $ treeValue x)
+        (fmap props $ treeChildren x)
+  in
+    fmap (MkProp . joinRose . fmap unProp) $
+      promote (props tree)


### PR DESCRIPTION
We can be more generous to folks with QuickCheck tests by allowing them to use hedgehog generators directly in their properties without sacrificing shrinking.

This is pretty explicity derived from @jacobstanley's code and QuickChecks's `forAll`.

I've run a bad example to show that it works fine with discards and predicates.
```
> let gInt = Gen.int (Range.constant 0 22)
> quickCheck $ Test.QuickCheck.Hedgehog.forAll (gInt >>= \i -> if even i then pure i else Gen.discard ) $ \x -> True Test.QuickCheck.=== (x < 18)
*** Failed! Falsified (after 2 tests and 2 shrinks):    
18
True /= False
```
