### PR TITLE
Add `Num (GenT m a)` instance

### DIFF
--- a/hedgehog/src/Hedgehog/Internal/Gen.hs
+++ b/hedgehog/src/Hedgehog/Internal/Gen.hs
@@ -507,7 +507,6 @@ instance (Monad m, Num a) => Num (GenT m a) where
     pure . fromInteger
 #endif
 
-
 instance Functor m => Functor (GenT m) where
   fmap f gen =
     GenT $ \seed size ->

--- a/hedgehog/src/Hedgehog/Internal/Gen.hs
+++ b/hedgehog/src/Hedgehog/Internal/Gen.hs
@@ -235,6 +235,8 @@ import qualified Control.Monad.Fail as Fail
 #endif
 #if __GLASGOW_HASKELL__ < 806
 import           Data.Coerce (coerce)
+#else
+import           Data.Monoid (Ap (..))
 #endif
 
 ------------------------------------------------------------------------
@@ -477,6 +479,34 @@ instance (Monad m, Monoid a) => Monoid (GenT m a) where
 
   mempty =
     return mempty
+
+#if __GLASGOW_HASKELL__ >= 806
+deriving via (Ap (GenT m) x)
+  instance (Monad m, Num x) => Num (GenT m x)
+#else
+instance (Monad m, Num x) => Num (GenT m x) where
+  (+) =
+    liftA2 (+)
+
+  (*) =
+    liftA2 (*)
+
+  (-) =
+    liftA2 (-)
+
+  negate =
+    fmap negate
+
+  abs =
+    fmap abs
+
+  signum =
+    fmap signum
+
+  fromInteger =
+    pure . fromInteger
+#endif
+
 
 instance Functor m => Functor (GenT m) where
   fmap f gen =

--- a/hedgehog/src/Hedgehog/Internal/Gen.hs
+++ b/hedgehog/src/Hedgehog/Internal/Gen.hs
@@ -481,10 +481,10 @@ instance (Monad m, Monoid a) => Monoid (GenT m a) where
     return mempty
 
 #if __GLASGOW_HASKELL__ >= 806
-deriving via (Ap (GenT m) x)
-  instance (Monad m, Num x) => Num (GenT m x)
+deriving via (Ap (GenT m) a)
+  instance (Monad m, Num a) => Num (GenT m a)
 #else
-instance (Monad m, Num x) => Num (GenT m x) where
+instance (Monad m, Num a) => Num (GenT m a) where
   (+) =
     liftA2 (+)
 


### PR DESCRIPTION
Hey!

I've been writing a little simulation library, and a lot of the functions depend on delaying an action by some vague interval, and so I decided I could just sample `Gen` types. This has led to expressions like `exactly 2 days`, `roughly 6 hours`, and so on (where `exactly` is effectively the `pure` generator, and `roughly` does some magic with a normal distribution). Yesterday, I realised I wanted to simulate something that took roughly three days, but at least one day. So, I thought it would be neat to write `exactly 1 day + roughly 2 days`. This would require the typical `deriving via Ap (GenT m x)` instance for `GenT`, so here it is 😄

I hope I've followed the style guide, and I've tested this on 8.10.4, 8.6.3, and 8.4.3, though I assume Travis will tell me if I've missed anything! I couldn't find a set of per-instance tests to add to, but please do let me know if I've missed something.

Thanks so much for this library, it's invaluable!