### PR TITLE
Tweak 'cover' example code in haddocks

### DIFF
--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -1248,8 +1248,8 @@ journalCoverage (Journal logs) =
 --    prop_with_coverage =
 --      property $ do
 --        match <- forAll Gen.bool
---        cover 30 "True" $ match
---        cover 30 "False" $ not match
+--        cover 30 \"True\" $ match
+--        cover 30 \"False\" $ not match
 -- @
 --
 --   The example above requires a minimum of 30% coverage for both


### PR DESCRIPTION
This is a minor thing :smile:  but I was totally confused for few minutes after staring at this example in haddocks (notice how True and False are rendered - but the 2nd argument of Cover is `LabelName`)

![Screenshot from 2021-06-23 09-01-43](https://user-images.githubusercontent.com/2716069/123051232-da73a580-d401-11eb-9f43-52ad13a91e46.png)

This might be some haddock bug - it renders `String` literals in other code blocks correctly, but for some reason it renders True and False in this case as (dead) links.

After this small fix the example is rendered correctly (tested locally):

![Screenshot from 2021-06-23 08-59-19](https://user-images.githubusercontent.com/2716069/123051403-0d1d9e00-d402-11eb-8352-2692865dae0b.png)

