### PR TITLE
Compatibility with the GHC 9.2 series

### DIFF
--- a/hedgehog-example/hedgehog-example.cabal
+++ b/hedgehog-example/hedgehog-example.cabal
@@ -66,7 +66,7 @@ library
     , process                         >= 1.2        && < 1.7
     , QuickCheck                      >= 2.7        && < 2.15
     , resourcet                       >= 1.1        && < 1.3
-    , template-haskell                >= 2.10       && < 2.17
+    , template-haskell                >= 2.10       && < 2.19
     , temporary                       >= 1.3        && < 1.4
     , temporary-resourcet             >= 0.1        && < 0.2
     , text                            >= 1.1        && < 1.3

--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -70,7 +70,7 @@ library
     , random                          >= 1.1        && < 1.3
     , resourcet                       >= 1.1        && < 1.3
     , stm                             >= 2.4        && < 2.6
-    , template-haskell                >= 2.10       && < 2.18
+    , template-haskell                >= 2.10       && < 2.19
     , text                            >= 1.1        && < 1.3
     , time                            >= 1.4        && < 1.13
     , transformers                    >= 0.5        && < 0.6

--- a/hedgehog/src/Hedgehog/Internal/Gen.hs
+++ b/hedgehog/src/Hedgehog/Internal/Gen.hs
@@ -473,7 +473,7 @@ instance (Monad m, Semigroup a) => Semigroup (GenT m a) where
 
 instance (Monad m, Monoid a) => Monoid (GenT m a) where
   mappend =
-    liftA2 mappend
+    (Semigroup.<>)
 
   mempty =
     return mempty

--- a/hedgehog/src/Hedgehog/Internal/Report.hs
+++ b/hedgehog/src/Hedgehog/Internal/Report.hs
@@ -142,16 +142,17 @@ data Summary =
 instance Monoid Summary where
   mempty =
     Summary 0 0 0 0 0
-  mappend (Summary x1 x2 x3 x4 x5) (Summary y1 y2 y3 y4 y5) =
+  mappend =
+    (<>)
+
+instance Semigroup Summary where
+  (Summary x1 x2 x3 x4 x5) <> (Summary y1 y2 y3 y4 y5) =
     Summary
       (x1 + y1)
       (x2 + y2)
       (x3 + y3)
       (x4 + y4)
       (x5 + y5)
-
-instance Semigroup Summary where
-  (<>) = mappend
 
 -- | Construct a summary from a single result.
 --


### PR DESCRIPTION
This series ships with template-haskell version 2.18, which was previous
excluded by the bounds. The bounds have been bumped in this commit.

Also, this series has a new warning about defining superclasses in terms
of their subclasses. In this commit, we resolve the warning by moving
the definitions to the superclasses. Also, instead of duplicating a
`mappend` definition, we define it in terms of `(<>)` on its Semigroup
superclass.