### PR TITLE
Apply patch for fixed seed with minor modifications. (updated)

### DIFF
--- a/hedgehog/src/Hedgehog/Internal/Config.hs
+++ b/hedgehog/src/Hedgehog/Internal/Config.hs
@@ -116,19 +116,27 @@ detectColor =
           else
             pure DisableColor
 
+splitOn :: String -> String -> [String]
+splitOn needle haystack =
+  fmap Text.unpack $ Text.splitOn (Text.pack needle) (Text.pack haystack)
+
+parseSeed :: String -> Maybe Seed
+parseSeed env =
+  case splitOn " " env of
+    [value, gamma] ->
+      Seed <$> readMaybe value <*> readMaybe gamma
+    _ ->
+      Nothing
+
 detectSeed :: MonadIO m => m Seed
 detectSeed =
   liftIO $ do
     menv <- lookupEnv "HEDGEHOG_SEED"
-    case menv of
+    case parseSeed =<< menv of
       Nothing ->
         Seed.random
-      Just env ->
-        let
-          [value, gamma] =
-            read . Text.unpack <$> Text.splitOn (Text.pack " ") (Text.pack env)
-        in
-          pure $ Seed value gamma
+      Just seed ->
+        pure seed
 
 detectVerbosity :: MonadIO m => m Verbosity
 detectVerbosity =

--- a/hedgehog/src/Hedgehog/Internal/Report.hs
+++ b/hedgehog/src/Hedgehog/Internal/Report.hs
@@ -63,7 +63,6 @@ import           Hedgehog.Internal.Property (TestCount(..), DiscardCount(..))
 import           Hedgehog.Internal.Property (coverPercentage, coverageFailures)
 import           Hedgehog.Internal.Property (labelCovered)
 
-import           Hedgehog.Internal.Seed (Seed)
 import           Hedgehog.Internal.Show
 import           Hedgehog.Internal.Source
 import           Hedgehog.Range (Size)

--- a/hedgehog/src/Hedgehog/Internal/Runner.hs
+++ b/hedgehog/src/Hedgehog/Internal/Runner.hs
@@ -48,7 +48,6 @@ import           Hedgehog.Internal.Property (defaultMinTests)
 import           Hedgehog.Internal.Queue
 import           Hedgehog.Internal.Region
 import           Hedgehog.Internal.Report
-import           Hedgehog.Internal.Seed (Seed)
 import qualified Hedgehog.Internal.Seed as Seed
 import           Hedgehog.Internal.Tree (TreeT(..), NodeT(..))
 import           Hedgehog.Range (Size)

--- a/hedgehog/src/Hedgehog/Internal/Seed.hs
+++ b/hedgehog/src/Hedgehog/Internal/Seed.hs
@@ -1,5 +1,6 @@
 {-# OPTIONS_HADDOCK not-home #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveLift #-}
 -- |
 -- This is a port of "Fast Splittable Pseudorandom Number Generators" by Steele
 -- et. al. [1].
@@ -61,6 +62,8 @@ import           Data.IORef (IORef)
 import qualified Data.IORef as IORef
 import           Data.Word (Word32, Word64)
 
+import           Language.Haskell.TH.Syntax (Lift)
+
 import           System.IO.Unsafe (unsafePerformIO)
 import           System.Random (RandomGen)
 import qualified System.Random as Random
@@ -71,7 +74,7 @@ data Seed =
   Seed {
       seedValue :: !Word64
     , seedGamma :: !Word64 -- ^ must be an odd number
-    } deriving (Eq, Ord)
+    } deriving (Eq, Ord, Lift)
 
 instance Show Seed where
   showsPrec p (Seed v g) =


### PR DESCRIPTION
I wasn't able to push to #424's branch so this is a rebase to check the build.

*edit: The 9.2 build found that a call to `read` resulted in a non-exhaustive pattern match so I have fixed that. Note that this means we now fail silently if `HEDGEHOG_SEED` can't be parsed. This is inline with how we handle the other environment variables which maybe isn't the best thing but is consistent at least. 😓*