### PR TITLE
Compatibility with text-2.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,12 @@ jobs:
         os:    [macos-latest, ubuntu-latest, windows-latest]
         cabal: ["3.4"]
         ghc:   ["8.0.2", "8.2.2", "8.4.4", "8.6.5", "8.8.4", "8.10.7", "9.2.1"]
+        exclude:
+          # https://github.com/haskell/text/pull/404
+          - os: windows-latest
+            ghc: "8.0.2"
+          - os: windows-latest
+            ghc: "8.2.2"
 
     runs-on: ${{ matrix.os }}
 

--- a/hedgehog-example/hedgehog-example.cabal
+++ b/hedgehog-example/hedgehog-example.cabal
@@ -57,7 +57,7 @@ library
     , containers                      >= 0.4        && < 0.7
     , directory                       >= 1.0        && < 1.4
     , filepath                        >= 1.3        && < 1.5
-    , hashtables                      >= 1.2        && < 1.3
+    , hashtables                      >= 1.2        && < 1.4
     , lifted-base                     >= 0.2        && < 0.3
     , mmorph                          >= 1.0        && < 1.2
     , mtl                             >= 2.1        && < 2.3
@@ -69,7 +69,7 @@ library
     , template-haskell                >= 2.10       && < 2.19
     , temporary                       >= 1.3        && < 1.4
     , temporary-resourcet             >= 0.1        && < 0.2
-    , text                            >= 1.1        && < 1.3
+    , text                            >= 1.1        && < 2.1
     , transformers                    >= 0.4        && < 0.6
 
 test-suite test

--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -72,7 +72,7 @@ library
     , resourcet                       >= 1.1        && < 1.3
     , stm                             >= 2.4        && < 2.6
     , template-haskell                >= 2.10       && < 2.19
-    , text                            >= 1.1        && < 1.3
+    , text                            >= 1.1        && < 2.1
     , time                            >= 1.4        && < 1.13
     , transformers                    >= 0.5        && < 0.6
     , transformers-base               >= 0.4.5.1    && < 0.5


### PR DESCRIPTION
Tested using

    cabal test --constraint='text>=2' all -w ghc-9.2.1

Fixes #443.

The test failures of old GHC versions on Windows are compiler bugs, it seems: haskell/text/pull/404