### PR TITLE
Add example for Gen.subsequence

### DIFF
--- a/hedgehog/src/Hedgehog/Internal/Gen.hs
+++ b/hedgehog/src/Hedgehog/Internal/Gen.hs
@@ -1661,6 +1661,20 @@ subterm3 gx gy gz f =
 
 -- | Generates a random subsequence of a list.
 --
+-- For example:
+--
+-- @
+-- Gen.print (Gen.subsequence [1..5])
+-- @
+--
+--   > === Outcome ===
+--   > [1,2,4]
+--   > === Shrinks ===
+--   > []
+--   > [2,4]
+--   > [1,4]
+--   > [1,2]
+--
 subsequence :: MonadGen m => [a] -> m [a]
 subsequence xs =
   shrink Shrink.list $ filterM (const bool_) xs


### PR DESCRIPTION
I thought an example on `Gen.subsequence` might be helpful to clarify that:

- Subsequences don't have to be contiguous
- Elements in the subsequence retain their ordering from the original sequence, and don't get shuffled around
- Subsequences shrink toward `[]` rather than toward the original list 