### PR TITLE
Don't drop actions depending on shrunk predecessors.

### DIFF
--- a/hedgehog/src/Hedgehog/Internal/State.hs
+++ b/hedgehog/src/Hedgehog/Internal/State.hs
@@ -548,6 +548,12 @@ action commands =
     Command mgenInput exec callbacks <-
       Gen.element_ $ filter (\c -> commandGenOK c state0) commands
 
+    -- If we shrink the input, we still want to use the same output. Otherwise
+    -- any actions using this output as part of their input will be dropped. But
+    -- the existing output is still in the context, so `contextNewVar` will
+    -- create a new one. To avoid that, we generate the output before the input.
+    output <- contextNewVar
+
     input <-
       case mgenInput state0 of
         Nothing ->
@@ -559,8 +565,6 @@ action commands =
       pure Nothing
 
     else do
-      output <- contextNewVar
-
       contextUpdate $
         callbackUpdate callbacks state0 input (Var output)
 


### PR DESCRIPTION
Closes #448. Suppose we have an Action list

    A 1 -> Var 0
    B (Var 0) -> ...

Then when we shrink A, we would previously get the list

    A 0 -> Var 1
    B (Var 0) -> ...

And then we'd drop B from this list, because `Var 0` no longer exists.
Now shrinking will give

    A 0 -> Var 0
    B (Var 0) -> ...

which is fine.

This means we now generate Vars even for actions whose `Require` fails.

I don't know if this is the ideal way to fix this. I wonder whether, when shrinking, the context should be rolled back so that the output we previously generated is no longer present? But I wouldn't know how to change that, and I'd be much less confident of not breaking anything else if I did.