### PR TITLE
Allow skipping to a specific test number or shrink result

### DIFF
--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -136,6 +136,7 @@ test-suite test
     Test.Hedgehog.Filter
     Test.Hedgehog.Maybe
     Test.Hedgehog.Seed
+    Test.Hedgehog.Skip
     Test.Hedgehog.Text
     Test.Hedgehog.Zip
 

--- a/hedgehog/src/Hedgehog.hs
+++ b/hedgehog/src/Hedgehog.hs
@@ -60,6 +60,7 @@ module Hedgehog (
 
   , check
   , recheck
+  , recheckAt
 
   , discover
   , discoverPrefix
@@ -193,7 +194,7 @@ import           Hedgehog.Internal.Property (Test, TestT, property, test)
 import           Hedgehog.Internal.Property (TestLimit, withTests)
 import           Hedgehog.Internal.Property (collect, label)
 import           Hedgehog.Internal.Range (Range, Size(..))
-import           Hedgehog.Internal.Runner (check, recheck, checkSequential, checkParallel)
+import           Hedgehog.Internal.Runner (check, recheck, recheckAt, checkSequential, checkParallel)
 import           Hedgehog.Internal.Seed (Seed(..))
 import           Hedgehog.Internal.State (Command(..), Callback(..))
 import           Hedgehog.Internal.State (Action, Sequential(..), Parallel(..))

--- a/hedgehog/src/Hedgehog.hs
+++ b/hedgehog/src/Hedgehog.hs
@@ -82,6 +82,9 @@ module Hedgehog (
   , withRetries
   , ShrinkRetries
 
+  , withSkip
+  , Skip
+
   -- * Generating Test Data
   , Gen
   , GenT
@@ -185,6 +188,7 @@ import           Hedgehog.Internal.Property (Group(..), GroupName)
 import           Hedgehog.Internal.Property (Confidence, verifiedTermination, withConfidence)
 import           Hedgehog.Internal.Property (ShrinkLimit, withShrinks)
 import           Hedgehog.Internal.Property (ShrinkRetries, withRetries)
+import           Hedgehog.Internal.Property (Skip, withSkip)
 import           Hedgehog.Internal.Property (Test, TestT, property, test)
 import           Hedgehog.Internal.Property (TestLimit, withTests)
 import           Hedgehog.Internal.Property (collect, label)

--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -378,7 +378,7 @@ instance IsString Skip where
   fromString s =
     case skipDecompress s of
       Nothing ->
-        error $ "Not a valid Skip: " ++ s
+        error $ "fromString: Not a valid Skip: " ++ s
       Just skip ->
         skip
 

--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -351,7 +351,7 @@ data Skip =
     SkipNothing
 
   -- | Skip to a specific test number. If it fails, shrink as normal. If it
-  --   passes, move on to the next test.
+  --   passes, move on to the next test. Coverage checks are disabled.
   --
   | SkipToTest TestCount
 

--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -369,7 +369,7 @@ data Skip =
 -- | We use this instance to support usage like
 --
 -- @
---   withTests "3:aB"
+--   withSkip "3:aB"
 -- @
 --
 --   It throws an error if the input is not a valid compressed 'Skip'.

--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -34,6 +34,7 @@ module Hedgehog.Internal.Property (
   , DiscardCount(..)
   , ShrinkLimit(..)
   , ShrinkCount(..)
+  , ShrinkPath(..)
   , ShrinkRetries(..)
   , withTests
   , withDiscards
@@ -330,6 +331,12 @@ newtype ShrinkLimit =
 newtype ShrinkCount =
   ShrinkCount Int
   deriving (Eq, Ord, Show, Num, Enum, Real, Integral)
+
+-- | The path taken to reach a shrink state.
+--
+newtype ShrinkPath =
+  ShrinkPath [Int]
+  deriving (Eq, Ord, Show)
 
 -- | The number of times to re-run a test during shrinking. This is useful if
 --   you are testing something which fails non-deterministically and you want to

--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -384,9 +384,6 @@ instance IsString Skip where
 
 -- | The path taken to reach a shrink state.
 --
---   This is in reverse order, most recent path element first, for efficient
---   appending.
---
 newtype ShrinkPath =
   ShrinkPath [Int]
   deriving (Eq, Ord, Show, Lift)
@@ -414,7 +411,7 @@ skipCompress = \case
 shrinkPathCompress :: ShrinkPath -> String
 shrinkPathCompress (ShrinkPath sp) =
   let
-    groups = List.map (\l -> (head l, length l)) $ List.group (reverse sp)
+    groups = List.map (\l -> (head l, length l)) $ List.group sp
   in
     (mconcat
       $ zipWith
@@ -494,7 +491,7 @@ shrinkPathDecompress str =
   in do
     sp <- concat <$>
       traverse (\(mNum, mCount) -> replicate <$> mCount <*> mNum) spGroups
-    Just $ ShrinkPath $ reverse sp
+    Just $ ShrinkPath sp
 
 -- | The number of times to re-run a test during shrinking. This is useful if
 --   you are testing something which fails non-deterministically and you want to

--- a/hedgehog/src/Hedgehog/Internal/Report.hs
+++ b/hedgehog/src/Hedgehog/Internal/Report.hs
@@ -58,10 +58,11 @@ import           Hedgehog.Internal.Prelude
 import           Hedgehog.Internal.Property (CoverCount(..), CoverPercentage(..))
 import           Hedgehog.Internal.Property (Coverage(..), Label(..), LabelName(..))
 import           Hedgehog.Internal.Property (PropertyName(..), Log(..), Diff(..))
-import           Hedgehog.Internal.Property (ShrinkCount(..), ShrinkPath(..), PropertyCount(..))
+import           Hedgehog.Internal.Property (ShrinkCount(..), PropertyCount(..))
 import           Hedgehog.Internal.Property (TestCount(..), DiscardCount(..))
 import           Hedgehog.Internal.Property (coverPercentage, coverageFailures)
 import           Hedgehog.Internal.Property (labelCovered)
+import           Hedgehog.Internal.Property (ShrinkPath(..), shrinkPathCompress)
 
 import           Hedgehog.Internal.Show
 import           Hedgehog.Internal.Source
@@ -328,8 +329,8 @@ ppShrinkCount = \case
   ShrinkCount n ->
     ppShow n <+> "shrinks"
 
-ppShrinkPath :: ShrinkPath -> Doc a
-ppShrinkPath (ShrinkPath p) = ppShow $ reverse p
+ppShrinkPath :: TestCount -> ShrinkPath -> Doc a
+ppShrinkPath tests path = WL.text $ shrinkPathCompress tests path
 
 ppRawPropertyCount :: PropertyCount -> Doc a
 ppRawPropertyCount (PropertyCount n) =
@@ -753,7 +754,7 @@ ppResult name (Report tests discards coverage result) = do
             ppShrinkDiscard (failureShrinks failure) discards <>
             "." <#>
             "shrink path:" <+>
-            ppShrinkPath (failureShrinkPath failure)
+            ppShrinkPath tests (failureShrinkPath failure)
             <> "."
         ] ++
         ppCoverage tests coverage ++

--- a/hedgehog/src/Hedgehog/Internal/Report.hs
+++ b/hedgehog/src/Hedgehog/Internal/Report.hs
@@ -66,7 +66,6 @@ import           Hedgehog.Internal.Property (ShrinkPath(..), skipCompress)
 
 import           Hedgehog.Internal.Show
 import           Hedgehog.Internal.Source
-import           Hedgehog.Range (Size)
 
 import           System.Console.ANSI (ColorIntensity(..), Color(..))
 import           System.Console.ANSI (ConsoleLayer(..), ConsoleIntensity(..))
@@ -92,8 +91,7 @@ data FailedAnnotation =
 
 data FailureReport =
   FailureReport {
-      failureSize :: !Size
-    , failureShrinks :: !ShrinkCount
+      failureShrinks :: !ShrinkCount
     , failureShrinkPath :: !ShrinkPath
     , failureCoverage :: !(Maybe (Coverage CoverCount))
     , failureAnnotations :: ![FailedAnnotation]
@@ -269,8 +267,7 @@ takeFootnote = \case
     Nothing
 
 mkFailure ::
-     Size
-  -> ShrinkCount
+     ShrinkCount
   -> ShrinkPath
   -> Maybe (Coverage CoverCount)
   -> Maybe Span
@@ -278,7 +275,7 @@ mkFailure ::
   -> Maybe Diff
   -> [Log]
   -> FailureReport
-mkFailure size shrinks shrinkPath mcoverage location message diff logs =
+mkFailure shrinks shrinkPath mcoverage location message diff logs =
   let
     inputs =
       mapMaybe takeAnnotation logs
@@ -286,7 +283,7 @@ mkFailure size shrinks shrinkPath mcoverage location message diff logs =
     footnotes =
       mapMaybe takeFootnote logs
   in
-    FailureReport size shrinks shrinkPath mcoverage inputs location message diff footnotes
+    FailureReport shrinks shrinkPath mcoverage inputs location message diff footnotes
 
 ------------------------------------------------------------------------
 -- Pretty Printing
@@ -626,7 +623,7 @@ ppTextLines =
   fmap WL.text . List.lines
 
 ppFailureReport :: MonadIO m => Maybe PropertyName -> TestCount -> Seed -> FailureReport -> m [Doc Markup]
-ppFailureReport name tests seed (FailureReport _ _ shrinkPath mcoverage inputs0 mlocation0 msg mdiff msgs0) = do
+ppFailureReport name tests seed (FailureReport _ shrinkPath mcoverage inputs0 mlocation0 msg mdiff msgs0) = do
   let
     basic =
       -- Move the failure message to the end section if we have

--- a/hedgehog/src/Hedgehog/Internal/Report.hs
+++ b/hedgehog/src/Hedgehog/Internal/Report.hs
@@ -62,7 +62,7 @@ import           Hedgehog.Internal.Property (ShrinkCount(..), PropertyCount(..))
 import           Hedgehog.Internal.Property (TestCount(..), DiscardCount(..))
 import           Hedgehog.Internal.Property (coverPercentage, coverageFailures)
 import           Hedgehog.Internal.Property (labelCovered)
-import           Hedgehog.Internal.Property (ShrinkPath(..), shrinkPathCompress)
+import           Hedgehog.Internal.Property (ShrinkPath(..), skipCompress)
 
 import           Hedgehog.Internal.Show
 import           Hedgehog.Internal.Source
@@ -330,7 +330,8 @@ ppShrinkCount = \case
     ppShow n <+> "shrinks"
 
 ppShrinkPath :: TestCount -> ShrinkPath -> Doc a
-ppShrinkPath tests path = WL.text $ shrinkPathCompress tests path
+ppShrinkPath tests path =
+  WL.text $ skipCompress $ SkipToShrink tests path
 
 ppRawPropertyCount :: PropertyCount -> Doc a
 ppRawPropertyCount (PropertyCount n) =

--- a/hedgehog/src/Hedgehog/Internal/Runner.hs
+++ b/hedgehog/src/Hedgehog/Internal/Runner.hs
@@ -147,9 +147,13 @@ takeSmallest size seed shrinks shrinkPath slimit retries updateUI = \case
           findM (zip [0..] xs) (Failed failure) $ \(n, m) -> do
             o <- runTreeN retries m
             if isFailure o then
-              let ShrinkPath oldPath = shrinkPath
-                  newPath = ShrinkPath (n:oldPath)
-              in Just <$> takeSmallest size seed (shrinks + 1) newPath slimit retries updateUI o
+              let
+                ShrinkPath oldPath =
+                  shrinkPath
+                newPath =
+                  ShrinkPath (n:oldPath)
+              in
+                Just <$> takeSmallest size seed (shrinks + 1) newPath slimit retries updateUI o
             else
               return Nothing
 
@@ -194,7 +198,8 @@ skipToShrink size seed (ShrinkPath shrinkPath) updateUI =
   go shrinks (s0:ss) = \case
     NodeT _ xs ->
       case drop s0 xs of
-        [] -> pure GaveUp
+        [] ->
+          pure GaveUp
         (x:_) -> do
           o <- runTreeT x
           go (shrinks + 1) ss o
@@ -212,7 +217,9 @@ checkReport ::
 checkReport cfg size0 seed0 test0 updateUI = do
   skip <- liftIO $ resolveSkip $ propertySkip cfg
 
-  let (mSkipToTest, mSkipToShrink) = case skip of
+  let
+    (mSkipToTest, mSkipToShrink) =
+      case skip of
         SkipNothing ->
           (Nothing, Nothing)
         SkipToTest t ->
@@ -220,7 +227,6 @@ checkReport cfg size0 seed0 test0 updateUI = do
         SkipToShrink t s ->
           (Just t, Just s)
 
-  let
     test =
       catchAll test0 (fail . show)
 
@@ -338,7 +344,9 @@ checkReport cfg size0 seed0 test0 updateUI = do
             (Just _, Just shrinkPath) -> do
               node <-
                 runTreeT . evalGenT size s0 . runTestT $ unPropertyT test
-              let mkReport = Report (tests + 1) discards coverage0
+              let
+                mkReport =
+                  Report (tests + 1) discards coverage0
               mkReport
                <$> skipToShrink size s0 shrinkPath (updateUI . mkReport) node
             _ -> do

--- a/hedgehog/src/Hedgehog/Internal/Runner.hs
+++ b/hedgehog/src/Hedgehog/Internal/Runner.hs
@@ -156,6 +156,49 @@ takeSmallest size seed shrinks shrinkPath slimit retries updateUI = \case
       Right () ->
         return OK
 
+-- | Follow a given shrink path, instead of searching exhaustively. Assume that
+-- the end of the path is minimal, and don't try to shrink any further than
+-- that.
+--
+-- This evaluates the test for all the shrinks on the path, but not ones
+-- off-path. Because the generator is mixed with the test code, it's probably
+-- not possible to avoid this.
+skipToShrink ::
+     MonadIO m
+  => Size
+  -> Seed
+  -> ShrinkPath
+  -> (Progress -> m ())
+  -> NodeT m (Maybe (Either Failure (), Journal))
+  -> m Result
+skipToShrink size seed (ShrinkPath shrinkPath) updateUI =
+  go 0 (reverse shrinkPath)
+ where
+  go shrinks [] = \case
+    NodeT Nothing _ ->
+      pure GaveUp
+
+    NodeT (Just (x, (Journal logs))) _ ->
+      case x of
+        Left (Failure loc err mdiff) -> do
+          let
+            failure =
+              mkFailure size seed shrinks (ShrinkPath shrinkPath) Nothing loc err mdiff (reverse logs)
+
+          updateUI $ Shrinking failure
+          pure $ Failed failure
+
+        Right () ->
+          return OK
+
+  go shrinks (s0:ss) = \case
+    NodeT _ xs ->
+      case drop s0 xs of
+        [] -> pure GaveUp
+        (x:_) -> do
+          o <- runTreeT x
+          go (shrinks + 1) ss o
+
 checkReport ::
      forall m.
      MonadIO m
@@ -167,9 +210,14 @@ checkReport ::
   -> (Report Progress -> m ())
   -> m (Report Result)
 checkReport cfg size0 seed0 test0 updateUI = do
-  -- This should be a parameter, but that would need changes in hspec-hedgehog.
+  -- These should be parameters (or rather, combined as one parameter), but that
+  -- would need changes in hspec-hedgehog.
   mSkipToTest <-
     liftIO $ fmap (TestCount . read) <$> lookupEnv "HEDGEHOG_SKIP_TO_TEST"
+
+  -- We reverse before printing, so we have to reverse when reading as well.
+  mSkipToShrink <- liftIO $
+    fmap (ShrinkPath . reverse . read) <$> lookupEnv "HEDGEHOG_SKIP_TO_SHRINK"
 
   let
     test =
@@ -277,12 +325,18 @@ checkReport cfg size0 seed0 test0 updateUI = do
 
       else
         case Seed.split seed of
-          (s0, s1) -> case mSkipToTest of
+          (s0, s1) -> case (mSkipToTest, mSkipToShrink) of
             -- If the report says failed "after 32 tests", the test number that
             -- failed was 31, but we want the user to be able to skip to 32 and
             -- start with the one that failed.
-            Just n | n > tests + 1 ->
+            (Just n, _) | n > tests + 1 ->
               loop (tests + 1) discards (size + 1) s1 coverage0
+            (Just _, Just shrinkPath) -> do
+              node <-
+                runTreeT . evalGenT size s0 . runTestT $ unPropertyT test
+              let mkReport = Report (tests + 1) discards coverage0
+              mkReport
+               <$> skipToShrink size s0 shrinkPath (updateUI . mkReport) node
             _ -> do
               node@(NodeT x _) <-
                 runTreeT . evalGenT size s0 . runTestT $ unPropertyT test

--- a/hedgehog/test/Test/Hedgehog/Skip.hs
+++ b/hedgehog/test/Test/Hedgehog/Skip.hs
@@ -1,0 +1,175 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
+
+module Test.Hedgehog.Skip where
+
+import           Control.Monad.IO.Class (MonadIO(..))
+import           Data.IORef (IORef)
+import qualified Data.IORef as IORef
+import           Hedgehog
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Internal.Config as Config
+import qualified Hedgehog.Internal.Property as Property
+import qualified Hedgehog.Internal.Runner as Runner
+import           Hedgehog.Internal.Report (Report(..), Result(..), FailureReport(..))
+
+-- | We use this property to help test skipping. It keeps a log of every time it
+--   runs in the 'IORef' it's passed.
+--
+--   It ignores its seed. It fails at size 2. When it shrinks, it initially
+--   shrinks to something that will pass, and then to something that will fail.
+skipTestProperty :: IORef [(Size, Int, Bool)] -> Property
+skipTestProperty logRef =
+  withTests 5 . property $ do
+    val@(_, _, shouldPass) <- forAll $ do
+      curSize <- Gen.sized pure
+      (shouldPass, nShrinks) <-
+        (,)
+          <$> Gen.shrink (\b -> if b then [] else [True]) (pure $ curSize /= 2)
+          <*> Gen.shrink (\n -> reverse [0 .. n-1]) (pure 3)
+      pure (curSize, nShrinks, shouldPass)
+
+    liftIO $ IORef.modifyIORef' logRef (val :)
+    assert shouldPass
+
+checkProp :: MonadIO m => Property -> m (Report Result)
+checkProp prop = do
+  seed <- Config.resolveSeed Nothing
+  liftIO $ Runner.checkReport (Property.propertyConfig prop)
+                              0
+                              seed
+                              (Property.propertyTest prop)
+                              (const $ pure ())
+
+prop_SkipNothing :: Property
+prop_SkipNothing =
+  withTests 1 . property $ do
+    logRef <- liftIO $ IORef.newIORef []
+    let
+      prop = Property.withSkip Property.SkipNothing $ skipTestProperty logRef
+
+    report <- checkProp prop
+    case reportStatus report of
+      Failed f -> do
+        failureShrinks f === 3
+        failureShrinkPath f === Property.ShrinkPath [1, 1, 1]
+
+      _ ->
+        failure
+
+    logs <- liftIO $ reverse <$> IORef.readIORef logRef
+    logs ===
+      [ (0, 3, True)
+      , (1, 3, True)
+      , (2, 3, False)
+      , (2, 3, True)
+      , (2, 2, False)
+      , (2, 2, True)
+      , (2, 1, False)
+      , (2, 1, True)
+      , (2, 0, False)
+      , (2, 0, True)
+      ]
+
+prop_SkipToFailingTest :: Property
+prop_SkipToFailingTest =
+  withTests 1 . property $ do
+    logRef <- liftIO $ IORef.newIORef []
+    let
+      prop = Property.withSkip (Property.SkipToTest 3) $ skipTestProperty logRef
+
+    report <- checkProp prop
+    case reportStatus report of
+      Failed f -> do
+        failureShrinks f === 3
+        failureShrinkPath f === Property.ShrinkPath [1, 1, 1]
+
+      _ ->
+        failure
+
+    logs <- liftIO $ reverse <$> IORef.readIORef logRef
+    logs ===
+      [ (2, 3, False)
+      , (2, 3, True)
+      , (2, 2, False)
+      , (2, 2, True)
+      , (2, 1, False)
+      , (2, 1, True)
+      , (2, 0, False)
+      , (2, 0, True)
+      ]
+
+prop_SkipPastFailingTest :: Property
+prop_SkipPastFailingTest =
+  withTests 1 . property $ do
+    logRef <- liftIO $ IORef.newIORef []
+    let
+      prop = Property.withSkip (Property.SkipToTest 4) $ skipTestProperty logRef
+
+    report <- checkProp prop
+    reportStatus report === OK
+
+    logs <- liftIO $ reverse <$> IORef.readIORef logRef
+    logs === [(3, 3, True), (4, 3, True)]
+
+prop_SkipToNoShrink :: Property
+prop_SkipToNoShrink =
+  withTests 1 . property $ do
+    logRef <- liftIO $ IORef.newIORef []
+    let
+      prop = Property.withSkip (Property.SkipToShrink 3 $ Property.ShrinkPath [])
+        $ skipTestProperty logRef
+
+    report <- checkProp prop
+    case reportStatus report of
+      Failed f -> do
+        failureShrinks f === 0
+        failureShrinkPath f === Property.ShrinkPath []
+
+      _ ->
+        failure
+
+    logs <- liftIO $ reverse <$> IORef.readIORef logRef
+    logs === [(2, 3, False)]
+
+prop_SkipToFailingShrink :: Property
+prop_SkipToFailingShrink =
+  withTests 1 . property $ do
+    logRef <- liftIO $ IORef.newIORef []
+    let
+      prop = Property.withSkip (Property.SkipToShrink 3 $ Property.ShrinkPath [1, 1])
+        $ skipTestProperty logRef
+
+    report <- checkProp prop
+    case reportStatus report of
+      Failed f -> do
+        failureShrinks f === 2
+        failureShrinkPath f === Property.ShrinkPath [1, 1]
+
+      _ ->
+        failure
+
+    logs <- liftIO $ reverse <$> IORef.readIORef logRef
+    logs === [(2, 3, False), (2, 2, False), (2, 1, False)]
+
+prop_SkipToPassingShrink :: Property
+prop_SkipToPassingShrink =
+  withTests 1 . property $ do
+    logRef <- liftIO $ IORef.newIORef []
+    let
+      -- ShrinkPath is stored in reverse order of what you'd expect.
+      prop = Property.withSkip (Property.SkipToShrink 3 $ Property.ShrinkPath [0, 1])
+        $ skipTestProperty logRef
+
+    report <- checkProp prop
+    reportStatus report === OK
+
+    logs <- liftIO $ reverse <$> IORef.readIORef logRef
+    logs === [(2, 3, False), (2, 2, False), (2, 2, True)]
+
+tests :: IO Bool
+tests =
+  checkParallel $$(discover)

--- a/hedgehog/test/Test/Hedgehog/Skip.hs
+++ b/hedgehog/test/Test/Hedgehog/Skip.hs
@@ -226,13 +226,11 @@ prop_compressDecompressExamples =
         [ (SkipNothing, "", [])
         , (SkipToTest 3, "3", ["03", "003"])
         , (SkipToTest 197, "197", ["0197", "00197"])
-
-        -- Shrink paths are in reverse order of what you'd expect.
-        , ( SkipToShrink 5 $ Property.ShrinkPath [0, 3, 2]
+        , ( SkipToShrink 5 $ Property.ShrinkPath [2, 3, 0]
           , "5:cDa"
           , ["5:CdA", "05:c1b0D1A1"]
           )
-        , ( SkipToShrink 21 $ Property.ShrinkPath [26, 27, 27, 3, 5]
+        , ( SkipToShrink 21 $ Property.ShrinkPath [5, 3, 27, 27, 26]
           , "21:fDbb2BA"
           , ["21:fDbbBBba"]
           )

--- a/hedgehog/test/Test/Hedgehog/Skip.hs
+++ b/hedgehog/test/Test/Hedgehog/Skip.hs
@@ -48,11 +48,12 @@ skipTestProperty logRef =
 checkProp :: MonadIO m => Property -> m (Report Result)
 checkProp prop = do
   seed <- Config.resolveSeed Nothing
-  liftIO $ Runner.checkReport (Property.propertyConfig prop)
-                              0
-                              seed
-                              (Property.propertyTest prop)
-                              (const $ pure ())
+  liftIO $ Runner.checkReport
+    (Property.propertyConfig prop)
+    0
+    seed
+    (Property.propertyTest prop)
+    (const $ pure ())
 
 prop_SkipNothing :: Property
 prop_SkipNothing =

--- a/hedgehog/test/test.hs
+++ b/hedgehog/test/test.hs
@@ -5,6 +5,7 @@ import qualified Test.Hedgehog.Confidence
 import qualified Test.Hedgehog.Filter
 import qualified Test.Hedgehog.Maybe
 import qualified Test.Hedgehog.Seed
+import qualified Test.Hedgehog.Skip
 import qualified Test.Hedgehog.Text
 import qualified Test.Hedgehog.Zip
 
@@ -17,6 +18,7 @@ main =
     , Test.Hedgehog.Filter.tests
     , Test.Hedgehog.Maybe.tests
     , Test.Hedgehog.Seed.tests
+    , Test.Hedgehog.Skip.tests
     , Test.Hedgehog.Text.tests
     , Test.Hedgehog.Zip.tests
     ]


### PR DESCRIPTION
This won't be good to merge as-is, but if the feature is desirable, I'd be happy to help get it ready, including making supporting PRs to other repositories. (hspec-hedgehog will need one, and support for the feature in hspec would be nice.)

Using environment variables, this lets the user either

* `HEDGEHOG_SKIP_TO_TEST`: Start testing at a specific test number, and then continue from there. If it fails it'll shrink, if it passes it'll move on to the next test. Or,
* `HEDGEHOG_SKIP_TO_SHRINK`: Test at a specific test number and shrink state. If it fails it won't shrink further, if it passes the test will pass. The shrink state is encoded as an alphanumeric string and printed below the test and shrink counts.

Caveat: I don't think it's possible to walk the shrink tree without running tests at all? Please correct me if I'm wrong about that. So in the second case, you run the test at the desired shrink state, plus all its parents in the tree. But you don't run it at any of the shrinks that didn't cause the test to fail.

The value for me is that when retrying tests, they often spend several minutes before they reach the failing test case. This can eliminate almost all of that time. Additionally, I often use print-debugging, and that gets awkward if there's output from passing tests below the output from the failed test. By telling the runner exactly where to stop shrinking, that problem goes away.