### PR TITLE
Clarify that subsequences are strictly smaller

### DIFF
--- a/hedgehog/src/Hedgehog/Internal/Gen.hs
+++ b/hedgehog/src/Hedgehog/Internal/Gen.hs
@@ -1661,7 +1661,7 @@ subterm3 gx gy gz f =
 ------------------------------------------------------------------------
 -- Combinators - Combinations & Permutations
 
--- | Generates a random subsequence of a list.
+-- | Generates a strictly smaller, random subsequence of a list.
 --
 -- For example:
 --


### PR DESCRIPTION
Considering `Data.List.subsequences` contains its own input:

```
> Data.List.subsequences [1,2,3]
[[],[1],[2],[1,2],[3],[1,3],[2,3],[1,2,3]]
```

it can be clarified that `Hedgehog.Gen.subsequence` *also* does ~not~.