### PR TITLE
Allow newer dependencies

### DIFF
--- a/hedgehog-example/hedgehog-example.cabal
+++ b/hedgehog-example/hedgehog-example.cabal
@@ -59,8 +59,8 @@ library
     , filepath                        >= 1.3        && < 1.5
     , hashtables                      >= 1.2        && < 1.4
     , lifted-base                     >= 0.2        && < 0.3
-    , mmorph                          >= 1.0        && < 1.2
-    , mtl                             >= 2.1        && < 2.3
+    , mmorph                          >= 1.0        && < 1.3
+    , mtl                             >= 2.1        && < 2.4
     , parsec                          >= 3.1        && < 3.2
     , pretty-show                     >= 1.6        && < 1.11
     , process                         >= 1.2        && < 1.7
@@ -70,7 +70,7 @@ library
     , temporary                       >= 1.3        && < 1.4
     , temporary-resourcet             >= 0.1        && < 0.2
     , text                            >= 1.1        && < 2.1
-    , transformers                    >= 0.4        && < 0.6
+    , transformers                    >= 0.4        && < 0.7
 
 test-suite test
   type:

--- a/hedgehog-quickcheck/hedgehog-quickcheck.cabal
+++ b/hedgehog-quickcheck/hedgehog-quickcheck.cabal
@@ -52,7 +52,7 @@ library
       base                            >= 3          && < 5
     , hedgehog                        >= 0.5        && < 1.2
     , QuickCheck                      >= 2.7        && < 2.15
-    , transformers                    >= 0.4        && < 0.6
+    , transformers                    >= 0.4        && < 0.7
 
   ghc-options:
     -Wall

--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -65,7 +65,7 @@ library
     , lifted-async                    >= 0.7        && < 0.11
     , mmorph                          >= 1.0        && < 1.3
     , monad-control                   >= 1.0        && < 1.1
-    , mtl                             >= 2.1        && < 2.3
+    , mtl                             >= 2.1        && < 2.4
     , pretty-show                     >= 1.6        && < 1.11
     , primitive                       >= 0.6        && < 0.8
     , random                          >= 1.1        && < 1.3
@@ -74,7 +74,7 @@ library
     , template-haskell                >= 2.10       && < 2.19
     , text                            >= 1.1        && < 2.1
     , time                            >= 1.4        && < 1.13
-    , transformers                    >= 0.5        && < 0.6
+    , transformers                    >= 0.5        && < 0.7
     , transformers-base               >= 0.4.5.1    && < 0.5
     , wl-pprint-annotated             >= 0.0        && < 0.2
 
@@ -144,10 +144,10 @@ test-suite test
     , base                            >= 3          && < 5
     , containers                      >= 0.4        && < 0.7
     , mmorph                          >= 1.0        && < 1.3
-    , mtl                             >= 2.1        && < 2.3
+    , mtl                             >= 2.1        && < 2.4
     , pretty-show                     >= 1.6        && < 1.11
-    , text                            >= 1.1        && < 1.3
-    , transformers                    >= 0.3        && < 0.6
+    , text                            >= 1.1        && < 2.1
+    , transformers                    >= 0.3        && < 0.7
 
   default-language:
     Haskell2010


### PR DESCRIPTION
Tested with the following addition to `cabal.project` (to fix `happy`):

```
source-repository-package
  type: git
  location: git@github.com:haskell/happy.git
  tag: cc0fc789a19b9c3bdb1b1ed29bf910f386cefdf7
  subdir: packages/tabular

source-repository-package
  type: git
  location: git@github.com:haskell/happy.git
  tag: cc0fc789a19b9c3bdb1b1ed29bf910f386cefdf7
  subdir: packages/grammar
```

And the following command line:

    cabal test all --constraint='mtl>=2.3' --constraint='transformers>=0.6' --constraint='mmorph>=1.2'

All test pass.

I don't think the happy override should be committed since it will be unnecessary soon when haskell/happy#236 is closed.

This follows up on bumps missed in #427 and #449.