### PR TITLE
GHC 9.4 compatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,8 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         os:    [macos-latest, ubuntu-latest, windows-latest]
-        cabal: ["3.4"]
-        ghc:   ["8.0.2", "8.2.2", "8.4.4", "8.6.5", "8.8.4", "8.10.7", "9.2.1"]
+        cabal: ["3.8.1.0"]
+        ghc:   ["8.0.2", "8.2.2", "8.4.4", "8.6.5", "8.8.4", "8.10.7", "9.2.4", "9.4.1"]
         exclude:
           # https://github.com/haskell/text/pull/404
           - os: windows-latest

--- a/hedgehog-example/hedgehog-example.cabal
+++ b/hedgehog-example/hedgehog-example.cabal
@@ -66,7 +66,7 @@ library
     , process                         >= 1.2        && < 1.7
     , QuickCheck                      >= 2.7        && < 2.15
     , resourcet                       >= 1.1        && < 1.3
-    , template-haskell                >= 2.10       && < 2.19
+    , template-haskell                >= 2.10       && < 2.20
     , temporary                       >= 1.3        && < 1.4
     , temporary-resourcet             >= 0.1        && < 0.2
     , text                            >= 1.1        && < 2.1

--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -71,7 +71,7 @@ library
     , random                          >= 1.1        && < 1.3
     , resourcet                       >= 1.1        && < 1.3
     , stm                             >= 2.4        && < 2.6
-    , template-haskell                >= 2.10       && < 2.19
+    , template-haskell                >= 2.10       && < 2.20
     , text                            >= 1.1        && < 2.1
     , time                            >= 1.4        && < 1.13
     , transformers                    >= 0.5        && < 0.7

--- a/hedgehog/src/Hedgehog/Internal/Gen.hs
+++ b/hedgehog/src/Hedgehog/Internal/Gen.hs
@@ -18,6 +18,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-} -- MonadBase
 #if __GLASGOW_HASKELL__ >= 806
 {-# LANGUAGE DerivingVia #-}


### PR DESCRIPTION
This allows compatibility with GHC 9.4. Tested with `cabal test -w ghc-9.4.1`.

The extension is added because of this new warning:

```
src/Hedgehog/Internal/Gen.hs:312:46: error: [-Wtype-equality-requires-operators, -Werror=type-equality-requires-operators]
    The use of ‘~’ without TypeOperators
    will become an error in a future GHC release.
    Suggested fix: Perhaps you intended to use TypeOperators
    |
312 | toTree :: forall m a. (MonadGen m, GenBase m ~ Identity) => m a -> m (Tree a)
```