### PR TITLE
Release 1.1.2 for compatibility with GHC 9.4 only

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,8 @@ on:
     types:
       - opened
       - synchronize
+      - edited
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,12 @@ jobs:
         os:    [macos-latest, ubuntu-latest, windows-latest]
         cabal: ["3.4"]
         ghc:   ["8.0.2", "8.2.2", "8.4.4", "8.6.5", "8.8.4", "8.10.7", "9.2.1"]
+        exclude:
+          # https://github.com/haskell/text/pull/404
+          - os: windows-latest
+            ghc: "8.0.2"
+          - os: windows-latest
+            ghc: "8.2.2"
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,8 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         os:    [macos-latest, ubuntu-latest, windows-latest]
-        cabal: ["3.4"]
-        ghc:   ["8.0.2", "8.2.2", "8.4.4", "8.6.5", "8.8.4", "8.10.7", "9.2.1"]
+        cabal: ["3.8.1.0"]
+        ghc:   ["8.0.2", "8.2.2", "8.4.4", "8.6.5", "8.8.4", "8.10.7", "9.2.4", "9.4.1"]
         exclude:
           # https://github.com/haskell/text/pull/404
           - os: windows-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Version 1.1.2 (2022-09-02)
+
+* Support GHC 9.4 ([#461][461], [@ysangkok][ysangkok])
+* Allow newer dependencies ([#457][457], [@ysangkok][ysangkok])
+
 ## Version 1.1.1 (2022-01-29)
 
 * Support using fixed seed via `HEDGEHOG_SEED` ([#446][446], [@simfleischman][simfleischman] / [@moodmosaic][moodmosaic])
@@ -241,10 +246,15 @@
   https://github.com/patrickt
 [simfleischman]:
   https://github.com/simfleischman
+[ysangkok]:
+   https://github.com/ysangkok
 [jhrcek]:
   https://github.com/jhrcek
 
-
+[461]:
+  https://github.com/hedgehogqa/haskell-hedgehog/pull/461
+[457]:
+  https://github.com/hedgehogqa/haskell-hedgehog/pull/457
 [446]:
   https://github.com/hedgehogqa/haskell-hedgehog/pull/446
 [436]:

--- a/hedgehog-example/hedgehog-example.cabal
+++ b/hedgehog-example/hedgehog-example.cabal
@@ -66,7 +66,7 @@ library
     , process                         >= 1.2        && < 1.7
     , QuickCheck                      >= 2.7        && < 2.15
     , resourcet                       >= 1.1        && < 1.3
-    , template-haskell                >= 2.10       && < 2.19
+    , template-haskell                >= 2.10       && < 2.20
     , temporary                       >= 1.3        && < 1.4
     , temporary-resourcet             >= 0.1        && < 0.2
     , text                            >= 1.1        && < 2.1

--- a/hedgehog-example/hedgehog-example.cabal
+++ b/hedgehog-example/hedgehog-example.cabal
@@ -57,7 +57,7 @@ library
     , containers                      >= 0.4        && < 0.7
     , directory                       >= 1.0        && < 1.4
     , filepath                        >= 1.3        && < 1.5
-    , hashtables                      >= 1.2        && < 1.3
+    , hashtables                      >= 1.2        && < 1.4
     , lifted-base                     >= 0.2        && < 0.3
     , mmorph                          >= 1.0        && < 1.2
     , mtl                             >= 2.1        && < 2.3
@@ -69,7 +69,7 @@ library
     , template-haskell                >= 2.10       && < 2.19
     , temporary                       >= 1.3        && < 1.4
     , temporary-resourcet             >= 0.1        && < 0.2
-    , text                            >= 1.1        && < 1.3
+    , text                            >= 1.1        && < 2.1
     , transformers                    >= 0.4        && < 0.6
 
 test-suite test

--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -71,7 +71,7 @@ library
     , random                          >= 1.1        && < 1.3
     , resourcet                       >= 1.1        && < 1.3
     , stm                             >= 2.4        && < 2.6
-    , template-haskell                >= 2.10       && < 2.19
+    , template-haskell                >= 2.10       && < 2.20
     , text                            >= 1.1        && < 2.1
     , time                            >= 1.4        && < 1.13
     , transformers                    >= 0.5        && < 0.6

--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -1,4 +1,4 @@
-version: 1.1.1
+version: 1.1.2
 
 name:
   hedgehog

--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -72,7 +72,7 @@ library
     , resourcet                       >= 1.1        && < 1.3
     , stm                             >= 2.4        && < 2.6
     , template-haskell                >= 2.10       && < 2.19
-    , text                            >= 1.1        && < 1.3
+    , text                            >= 1.1        && < 2.1
     , time                            >= 1.4        && < 1.13
     , transformers                    >= 0.5        && < 0.6
     , transformers-base               >= 0.4.5.1    && < 0.5

--- a/hedgehog/src/Hedgehog/Internal/Gen.hs
+++ b/hedgehog/src/Hedgehog/Internal/Gen.hs
@@ -18,6 +18,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-} -- MonadBase
 #if __GLASGOW_HASKELL__ >= 806
 {-# LANGUAGE DerivingVia #-}


### PR DESCRIPTION
As suggested/discussed over in https://github.com/qfpl/tasty-hedgehog/issues/61#issuecomment-1234009175, here's a branch for a possible 1.1.2 release that builds on [the last commit for the 1.1.1 release](https://github.com/hedgehogqa/haskell-hedgehog/commit/bf04960348d0a32aab9dc8ff39c93b7743fa1153) and cherry-picks https://github.com/hedgehogqa/haskell-hedgehog/commit/4a4d5634f8f5e1c2476796bb88cf22b2ba3c276e and https://github.com/hedgehogqa/haskell-hedgehog/commit/5a03c900bf3d765ec5bf5739e4fc5d8fa0f4f0fd. **This should not actually be merged into `master`**, but should just be used for a Hackage release, although we might want to update the changelog in `master` to include this release / add this branch to this repository somewhere. 