### PR TITLE
Grow size faster with a small number of tests

### DIFF
--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -137,6 +137,7 @@ test-suite test
     Test.Hedgehog.Filter
     Test.Hedgehog.Maybe
     Test.Hedgehog.Seed
+    Test.Hedgehog.Size
     Test.Hedgehog.Skip
     Test.Hedgehog.Text
     Test.Hedgehog.Zip

--- a/hedgehog/src/Hedgehog.hs
+++ b/hedgehog/src/Hedgehog.hs
@@ -59,7 +59,6 @@ module Hedgehog (
   , discard
 
   , check
-  , recheck
   , recheckAt
 
   , discover
@@ -194,7 +193,7 @@ import           Hedgehog.Internal.Property (Test, TestT, property, test)
 import           Hedgehog.Internal.Property (TestLimit, withTests)
 import           Hedgehog.Internal.Property (collect, label)
 import           Hedgehog.Internal.Range (Range, Size(..))
-import           Hedgehog.Internal.Runner (check, recheck, recheckAt, checkSequential, checkParallel)
+import           Hedgehog.Internal.Runner (check, recheckAt, checkSequential, checkParallel)
 import           Hedgehog.Internal.Seed (Seed(..))
 import           Hedgehog.Internal.State (Command(..), Callback(..))
 import           Hedgehog.Internal.State (Action, Sequential(..), Parallel(..))

--- a/hedgehog/src/Hedgehog/Internal/Runner.hs
+++ b/hedgehog/src/Hedgehog/Internal/Runner.hs
@@ -12,7 +12,6 @@
 module Hedgehog.Internal.Runner (
   -- * Running Individual Properties
     check
-  , recheck
   , recheckAt
 
   -- * Running Groups of Properties
@@ -41,7 +40,7 @@ import           Hedgehog.Internal.Property (Group(..), GroupName(..))
 import           Hedgehog.Internal.Property (Journal(..), Coverage(..), CoverCount(..))
 import           Hedgehog.Internal.Property (Property(..), PropertyConfig(..), PropertyName(..))
 import           Hedgehog.Internal.Property (PropertyT(..), Failure(..), runTestT)
-import           Hedgehog.Internal.Property (ShrinkLimit, ShrinkRetries, withTests, withSkip)
+import           Hedgehog.Internal.Property (ShrinkLimit, ShrinkRetries, withSkip)
 import           Hedgehog.Internal.Property (TerminationCriteria(..))
 import           Hedgehog.Internal.Property (TestCount(..), PropertyCount(..))
 import           Hedgehog.Internal.Property (confidenceSuccess, confidenceFailure)
@@ -425,16 +424,8 @@ check prop = do
   liftIO . displayRegion $ \region ->
     (== OK) . reportStatus <$> checkNamed region color Nothing Nothing prop
 
--- | Check a property using a specific size and seed.
+-- | Check a property using a specific seed and skip.
 --
-recheck :: MonadIO m => Size -> Seed -> Property -> m ()
-recheck size seed prop0 = do
-  color <- detectColor
-  let prop = withTests 1 prop0
-  _ <- liftIO . displayRegion $ \region ->
-    checkRegion region color Nothing size seed prop
-  pure ()
-
 recheckAt :: MonadIO m => Seed -> Skip -> Property -> m ()
 recheckAt seed skip prop0 = do
   color <- detectColor

--- a/hedgehog/test/Test/Hedgehog/Size.hs
+++ b/hedgehog/test/Test/Hedgehog/Size.hs
@@ -1,0 +1,86 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Test.Hedgehog.Size where
+
+import           Control.Monad                  ( void, when )
+import           Control.Monad.IO.Class         ( MonadIO(..) )
+
+import           Data.Foldable                  ( for_ )
+import qualified Data.IORef                    as IORef
+
+import           Hedgehog
+import qualified Hedgehog.Gen                  as Gen
+import qualified Hedgehog.Internal.Config      as Config
+import qualified Hedgehog.Internal.Property    as Property
+import           Hedgehog.Internal.Report       ( Report(..)
+                                                , Result(..)
+                                                )
+import qualified Hedgehog.Internal.Runner      as Runner
+
+checkProp :: MonadIO m => Property -> m (Report Result)
+checkProp prop = do
+  seed <- Config.resolveSeed Nothing
+  liftIO $ Runner.checkReport (Property.propertyConfig prop)
+                              seed
+                              (Property.propertyTest prop)
+                              (const $ pure ())
+
+checkGrowth ::
+  MonadIO m => (Property -> Property) -> [Size] -> m [Size]
+checkGrowth applyTerminationCriteria discardOn = do
+  logRef <- liftIO $ IORef.newIORef []
+
+  void $ checkProp $ applyTerminationCriteria $ property $ do
+    curSize <- forAll $ Gen.sized pure
+    liftIO $ IORef.modifyIORef' logRef (curSize :)
+    when (curSize `elem` discardOn) discard
+
+  liftIO $ reverse <$> IORef.readIORef logRef
+
+data GrowthTest =
+  GrowthTest
+    TestLimit -- ^ number of tests to run
+    [Size]    -- ^ which sizes should be discarded
+    [Size]    -- ^ the expected sizes run at (including ones discarded) for
+              --   NoConfidenceTermination and NoEarlyTermination
+    [Size]    -- ^ the expected sizes run at (including ones discarded) for
+              --   EarlyTermination
+
+growthTests :: [GrowthTest]
+growthTests =
+  [ GrowthTest 1   [] [0]                          [0 .. 99]
+  , GrowthTest 5   [] [0, 24 .. 96]                [0 .. 99]
+  , GrowthTest 10  [] [0, 11 .. 99]                [0 .. 99]
+  , GrowthTest 101 [] ([0 .. 99] ++ [0])           [0 .. 99]
+  , GrowthTest 105 [] ([0 .. 99] ++ [0, 24 .. 96]) [0 .. 99]
+  , GrowthTest 5   [24] (concat [[0], replicate 10 24, [25, 48, 72, 96]])
+                        (concat [[0 .. 23], replicate 10 24, [25], [25 .. 99]])
+  , let discards = concat [ replicate 10 96
+                          , replicate 10 97
+                          , replicate 10 98
+                          , replicate 70 99 -- discard limit is 100
+                          ]
+    in GrowthTest 5 [96 .. 99] ([0, 24 .. 72] ++ discards)
+                               ([0 .. 95] ++ discards)
+  ]
+
+prop_GrowthTest :: Property
+prop_GrowthTest =
+  withTests 1 . property $ do
+    for_ growthTests $
+      \(GrowthTest testLimit discardOn expected1 expected2) -> do
+        let noConfidenceTerm = withTests testLimit
+        sizes1 <- checkGrowth noConfidenceTerm discardOn
+        sizes1 === expected1
+
+        let noEarlyTerm = withConfidence 1000 . noConfidenceTerm
+        sizes2 <- checkGrowth noEarlyTerm discardOn
+        sizes2 === expected1
+
+        let earlyTerm = verifiedTermination . noEarlyTerm
+        sizes3 <- checkGrowth earlyTerm discardOn
+        sizes3 === expected2
+
+tests :: IO Bool
+tests =
+  checkParallel $$(discover)

--- a/hedgehog/test/test.hs
+++ b/hedgehog/test/test.hs
@@ -5,6 +5,7 @@ import qualified Test.Hedgehog.Confidence
 import qualified Test.Hedgehog.Filter
 import qualified Test.Hedgehog.Maybe
 import qualified Test.Hedgehog.Seed
+import qualified Test.Hedgehog.Size
 import qualified Test.Hedgehog.Skip
 import qualified Test.Hedgehog.Text
 import qualified Test.Hedgehog.Zip
@@ -18,6 +19,7 @@ main =
     , Test.Hedgehog.Filter.tests
     , Test.Hedgehog.Maybe.tests
     , Test.Hedgehog.Seed.tests
+    , Test.Hedgehog.Size.tests
     , Test.Hedgehog.Skip.tests
     , Test.Hedgehog.Text.tests
     , Test.Hedgehog.Zip.tests


### PR DESCRIPTION
As described in https://github.com/hedgehogqa/haskell-hedgehog/issues/472. We now grow test size in fixed increments from 0 to 99, or as close as we can without going over, in however many tests we run. If we run over *n* * 100 tests, then we go from 0 to 99 *n* times, and then do fixed increments for the remainder. Additionally, if we discard a bunch of times in a row we start to grow the size.

This will be helpful for https://github.com/proda-ai/excelsior/pull/8811, where currently we do 10 tests at a time and use sizes that would be larger than intended if we did more.

I've removed `recheck` because "specify the starting size" doesn't really make sense with this, and that function is no longer suggested by failure reports. If this goes upstream I dunno if they'll want to keep it for backwards compatibility, but we can figure something out if so.