### PR TITLE
Export Hedgehog.Internal.Seed.seed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 1.2.1 (unreleased)
+
+* Export `Hedgehog.Internal.Seed.seed` ([#477][477], [@sol][sol])
+
 ## Version 1.2 (2022-08-28)
 
 * Allow skipping to a specific test number or shrink result ([#454][454], [@ChickenProp][ChickenProp])

--- a/hedgehog/src/Hedgehog/Internal/Seed.hs
+++ b/hedgehog/src/Hedgehog/Internal/Seed.hs
@@ -46,6 +46,7 @@ module Hedgehog.Internal.Seed (
   , mix64variant13
   , mix32
   , mixGamma
+  , global
   ) where
 
 import           Control.Monad.IO.Class (MonadIO(..))


### PR DESCRIPTION
This e.g. allows you to control the output of `sample` when writing documentation / doctests.