### PR TITLE
Improve docs: `Gen.filter[T]`, `Gen.mapMaybe[T]`, `Tree.prune`.

### DIFF
--- a/hedgehog/src/Hedgehog/Internal/Tree.hs
+++ b/hedgehog/src/Hedgehog/Internal/Tree.hs
@@ -188,7 +188,7 @@ expand f m =
     pure . NodeT x $
       fmap (expand f) xs ++ unfoldForest f x
 
--- | Throw away @n@ levels of a tree's children.
+-- | Throw away all but the top @n@ levels of a tree's children.
 --
 --   /@prune 0@ will throw away all of a tree's children./
 --


### PR DESCRIPTION
`prune`'s documentation was incorrect. `filter`'s was at best misleading, and in any case not detailed enough for me to avoid pitfalls (#484). The others were missing entirely.