### PR TITLE
Fix test skipping when tests have been discarded.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 1.4 (unreleased)
+
+* Fix skipping to tests/shrinks when tests have been discarded ([#489][489], [@ChickenProp][ChickenProp])
+
 ## Version 1.3 (2023-06-22)
 
 * Better documentation for `Var` ([#491][491], [@endgame][endgame])

--- a/hedgehog/src/Hedgehog/Internal/Report.hs
+++ b/hedgehog/src/Hedgehog/Internal/Report.hs
@@ -622,8 +622,8 @@ ppTextLines :: String -> [Doc Markup]
 ppTextLines =
   fmap WL.text . List.lines
 
-ppFailureReport :: MonadIO m => Maybe PropertyName -> TestCount -> Seed -> FailureReport -> m [Doc Markup]
-ppFailureReport name tests seed (FailureReport _ shrinkPath mcoverage inputs0 mlocation0 msg mdiff msgs0) = do
+ppFailureReport :: MonadIO m => Maybe PropertyName -> TestCount -> DiscardCount -> Seed -> FailureReport -> m [Doc Markup]
+ppFailureReport name tests discards seed (FailureReport _ shrinkPath mcoverage inputs0 mlocation0 msg mdiff msgs0) = do
   let
     basic =
       -- Move the failure message to the end section if we have
@@ -696,7 +696,7 @@ ppFailureReport name tests seed (FailureReport _ shrinkPath mcoverage inputs0 ml
 
     bottom =
       maybe
-        [ppReproduce name seed (SkipToShrink tests shrinkPath)]
+        [ppReproduce name seed (SkipToShrink tests discards shrinkPath)]
         (const [])
         mcoverage
 
@@ -752,7 +752,7 @@ ppResult :: MonadIO m => Maybe PropertyName -> Report Result -> m (Doc Markup)
 ppResult name (Report tests discards coverage seed result) = do
   case result of
     Failed failure -> do
-      pfailure <- ppFailureReport name tests seed failure
+      pfailure <- ppFailureReport name tests discards seed failure
       pure . WL.vsep $ [
           icon FailedIcon '✗' . WL.align . WL.annotate FailedText $
             ppName name <+>
@@ -762,7 +762,7 @@ ppResult name (Report tests discards coverage seed result) = do
             ppShrinkDiscard (failureShrinks failure) discards <>
             "." <#>
             "shrink path:" <+>
-            ppSkip (SkipToShrink tests $ failureShrinkPath failure)
+            ppSkip (SkipToShrink tests discards $ failureShrinkPath failure)
         ] ++
         ppCoverage tests coverage ++
         pfailure

--- a/hedgehog/src/Hedgehog/Internal/Runner.hs
+++ b/hedgehog/src/Hedgehog/Internal/Runner.hs
@@ -220,10 +220,10 @@ checkReport cfg size0 seed0 test0 updateUI = do
       case skip of
         SkipNothing ->
           (Nothing, Nothing)
-        SkipToTest t ->
-          (Just t, Nothing)
-        SkipToShrink t s ->
-          (Just t, Just s)
+        SkipToTest t d ->
+          (Just (t, d), Nothing)
+        SkipToShrink t d s ->
+          (Just (t, d), Just s)
 
     test =
       catchAny test0 (fail . show)
@@ -335,8 +335,11 @@ checkReport cfg size0 seed0 test0 updateUI = do
             -- If the report says failed "after 32 tests", the test number that
             -- failed was 31, but we want the user to be able to skip to 32 and
             -- start with the one that failed.
-            (Just n, _) | n > tests + 1 ->
-              loop (tests + 1) discards (size + 1) s1 coverage0
+            (Just (n, d), _)
+              | n > tests + 1 ->
+                loop (tests + 1) discards (size + 1) s1 coverage0
+              | d > discards ->
+                loop tests (discards + 1) (size + 1) s1 coverage0
             (Just _, Just shrinkPath) -> do
               node <-
                 runTreeT . evalGenT size s0 . runTestT $ unPropertyT test


### PR DESCRIPTION
Closes #487.

In #454 we introduced test skipping, with the idea that a failed test could report a way for you to jump back to reproduce it without all the preceding tests.

But it didn't work if any of the preceding tests had been discarded, because each discard also changes the seed and the size. Users could manually add the discard count to the test count in the `Skip`, but that's no fun. Plus, it wouldn't work if the test count plus discard count exceeded the test limit, because that would generate a success without running any tests.

So now a `Skip` (other than `SkipNothing`) includes a `DiscardCount` as well as a `TestCount`. It's rendered in the compressed path as `testCount/discardCount`, or just `testCount` if `discardCount` is 0. The exact sequence of passing tests and discards doesn't affect the final seed or size, so the counts are all we need.

This changes an exposed type, so PVP requires a major version bump.

This is awkward for me personally because it's incompatible with the approach I took in #474, I'll leave a comment there with more details.