### PR TITLE
Relax upper bound on `ansi-terminal`

### DIFF
--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -52,7 +52,7 @@ library
   build-depends:
    -- GHC 8.0.1 / base-4.9.0.0 (May 2016)
       base                            >= 4.9        && < 5
-    , ansi-terminal                   >= 0.6        && < 1.1
+    , ansi-terminal                   >= 0.6        && < 1.2
     , async                           >= 2.0        && < 2.3
     , barbies                         >= 1.0        && < 2.2
     , bytestring                      >= 0.10       && < 0.13


### PR DESCRIPTION
Relax upper bound on `ansi-terminal` to permit `ansi-terminal-1.1`.

This resolves https://github.com/hedgehogqa/haskell-hedgehog/issues/511 by @mpilgrem.