### PR TITLE
hedgehog-{example,quickcheck,test-laws}: Raise QuickCheck bound

### DIFF
--- a/hedgehog-example/hedgehog-example.cabal
+++ b/hedgehog-example/hedgehog-example.cabal
@@ -64,7 +64,7 @@ library
     , parsec                          >= 3.1        && < 3.2
     , pretty-show                     >= 1.6        && < 1.11
     , process                         >= 1.2        && < 1.7
-    , QuickCheck                      >= 2.7        && < 2.15
+    , QuickCheck                      >= 2.7        && < 2.16
     , resourcet                       >= 1.1        && < 1.4
     , template-haskell                >= 2.10       && < 2.22
     , temporary                       >= 1.3        && < 1.4

--- a/hedgehog-quickcheck/hedgehog-quickcheck.cabal
+++ b/hedgehog-quickcheck/hedgehog-quickcheck.cabal
@@ -51,7 +51,7 @@ library
   build-depends:
       base                            >= 3          && < 5
     , hedgehog                        >= 0.5        && < 1.5
-    , QuickCheck                      >= 2.7        && < 2.15
+    , QuickCheck                      >= 2.7        && < 2.16
     , transformers                    >= 0.4        && < 0.7
 
   ghc-options:

--- a/hedgehog-test-laws/hedgehog-test-laws.cabal
+++ b/hedgehog-test-laws/hedgehog-test-laws.cabal
@@ -56,7 +56,7 @@ test-suite test
     , base                            >= 3          && < 5
       -- https://github.com/conal/checkers/issues/44
     , checkers                        >= 0.5        && < 0.5.5
-    , QuickCheck                      >= 2.10       && < 2.15
+    , QuickCheck                      >= 2.10       && < 2.16
     , tasty                           >= 1.2        && < 1.3
     , tasty-expected-failure          >= 0.11       && < 0.12
     , tasty-quickcheck                >= 0.10       && < 0.11


### PR DESCRIPTION
We have an `allow-newer: hedgehog-quickcheck:QuickCheck` working internally, and this PR passed `cabal test all --constraint 'QuickCheck ^>=2.15'`.

Can we please also get metadata revisions on Hackage?