### PR TITLE
Add callstacks to generators that can error.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,11 +14,9 @@ jobs:
       matrix:
         os:    [macos-latest, ubuntu-latest, windows-latest]
         cabal: ["3.10.1.0"]
-        ghc:   ["8.0.2", "8.2.2", "8.4.4", "8.6.5", "8.8.4", "8.10.7", "9.2.7", "9.4.4", "9.8.2", "9.10.1"]
+        ghc:   ["8.2.2", "8.4.4", "8.6.5", "8.8.4", "8.10.7", "9.2.7", "9.4.4", "9.8.2", "9.10.1"]
         exclude:
           # https://github.com/haskell/text/pull/404
-          - os: windows-latest
-            ghc: "8.0.2"
           - os: windows-latest
             ghc: "8.2.2"
 
@@ -53,4 +51,4 @@ jobs:
       - name: Build haddock
         run: |
           cabal haddock all
-        if: matrix.ghc != '8.0.2' && matrix.ghc != '8.2.2' && matrix.ghc != '8.4.4'
+        if: matrix.ghc != '8.2.2' && matrix.ghc != '8.4.4'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Version 1.6 (unreleased)
+## Version 1.6 (2024-08-27)
 
 * Add callstacks to generators that can error ([#538][538], [@ChickenProp][ChickenProp])
 * Drop support for GHC 8.0.2 ([#538][538], [@ChickenProp][ChickenProp])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Version 1.6 (unreleased)
+
+* Add callstacks to generators that can error ([#538][538], [@ChickenProp][ChickenProp])
+* Drop support for GHC 8.0.2 ([#538][538], [@ChickenProp][ChickenProp])
+
 ## Version 1.5 (2024-07-25)
 
 * Bump containers and filepath dependencies ([#533][533], [@erikd][erikd])
@@ -316,6 +321,8 @@
 [Vekhir]:
   https://github.com/Vekhir
 
+[538]:
+  https://github.com/hedgehogqa/haskell-hedgehog/pull/538
 [533]:
   https://github.com/hedgehogqa/haskell-hedgehog/pull/533
 [531]:

--- a/hedgehog-quickcheck/hedgehog-quickcheck.cabal
+++ b/hedgehog-quickcheck/hedgehog-quickcheck.cabal
@@ -50,7 +50,7 @@ source-repository head
 library
   build-depends:
       base                            >= 3          && < 5
-    , hedgehog                        >= 0.5        && < 1.6
+    , hedgehog                        >= 0.5        && < 1.7
     , QuickCheck                      >= 2.7        && < 2.16
     , transformers                    >= 0.4        && < 0.7
 

--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -33,8 +33,7 @@ cabal-version:
 build-type:
   Simple
 tested-with:
-    GHC == 8.0.2
-  , GHC == 8.2.2
+    GHC == 8.2.2
   , GHC == 8.4.4
   , GHC == 8.6.5
   , GHC == 8.8.3

--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -1,4 +1,4 @@
-version: 1.5
+version: 1.6
 
 name:
   hedgehog


### PR DESCRIPTION
Previously, `val <- Gen.element []` would give an error like

    Hedgehog.Gen.element: used with empty Foldable
    CallStack (from HasCallStack):
      error, called at src/Hedgehog/Internal/Gen.hs:1197:5 in hedgehog-1.4-FEcjASqhnyiHkb8BJanjYM:Hedgehog.Internal.Gen

Which isn't very helpful. Now the callstack entry points to my own code, instead.

I guess this will need a version bump since it changes types?

I think I got all the generators that are expected to throw errors. Some call `error` but describe it as internal, and I didn't touch those.