### PR TITLE
Support for GHC 9.12

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os:    [macos-latest, ubuntu-latest, windows-latest]
         cabal: ["3.10.1.0"]
-        ghc:   ["8.2.2", "8.4.4", "8.6.5", "8.8.4", "8.10.7", "9.2.7", "9.4.4", "9.8.2", "9.10.1"]
+        ghc:   ["8.2.2", "8.4.4", "8.6.5", "8.8.4", "8.10.7", "9.2.7", "9.4.4", "9.8.2", "9.10.1", "9.12.1"]
         exclude:
           # https://github.com/haskell/text/pull/404
           - os: windows-latest

--- a/hedgehog-corpus/hedgehog-corpus.cabal
+++ b/hedgehog-corpus/hedgehog-corpus.cabal
@@ -34,6 +34,11 @@ tested-with:
   , GHC == 8.6.5
   , GHC == 8.8.3
   , GHC == 8.10.1
+  , GHC == 9.2.7
+  , GHC == 9.4.4
+  , GHC == 9.8.2
+  , GHC == 9.10.1
+  , GHC == 9.12.1
 extra-source-files:
   README.md
 

--- a/hedgehog-dieharder/hedgehog-dieharder.cabal
+++ b/hedgehog-dieharder/hedgehog-dieharder.cabal
@@ -31,6 +31,11 @@ tested-with:
   , GHC == 8.6.5
   , GHC == 8.8.3
   , GHC == 8.10.1
+  , GHC == 9.2.7
+  , GHC == 9.4.4
+  , GHC == 9.8.2
+  , GHC == 9.10.1
+  , GHC == 9.12.1
 
 executable dieharder-input
   main-is:

--- a/hedgehog-example/hedgehog-example.cabal
+++ b/hedgehog-example/hedgehog-example.cabal
@@ -29,6 +29,11 @@ tested-with:
   , GHC == 8.6.5
   , GHC == 8.8.3
   , GHC == 8.10.1
+  , GHC == 9.2.7
+  , GHC == 9.4.4
+  , GHC == 9.8.2
+  , GHC == 9.10.1
+  , GHC == 9.12.1
 
 library
   hs-source-dirs:
@@ -66,7 +71,7 @@ library
     , process                         >= 1.2        && < 1.7
     , QuickCheck                      >= 2.7        && < 2.16
     , resourcet                       >= 1.1        && < 1.4
-    , template-haskell                >= 2.10       && < 2.23
+    , template-haskell                >= 2.10       && < 2.24
     , temporary                       >= 1.3        && < 1.4
     , temporary-resourcet             >= 0.1        && < 0.2
     , text                            >= 1.1        && < 2.2

--- a/hedgehog-quickcheck/hedgehog-quickcheck.cabal
+++ b/hedgehog-quickcheck/hedgehog-quickcheck.cabal
@@ -39,6 +39,11 @@ tested-with:
   , GHC == 8.6.5
   , GHC == 8.8.3
   , GHC == 8.10.1
+  , GHC == 9.2.7
+  , GHC == 9.4.4
+  , GHC == 9.8.2
+  , GHC == 9.10.1
+  , GHC == 9.12.1
 extra-source-files:
   README.md
   CHANGELOG.md

--- a/hedgehog-test-laws/hedgehog-test-laws.cabal
+++ b/hedgehog-test-laws/hedgehog-test-laws.cabal
@@ -33,6 +33,11 @@ tested-with:
   , GHC == 8.6.5
   , GHC == 8.8.3
   , GHC == 8.10.1
+  , GHC == 9.2.7
+  , GHC == 9.4.4
+  , GHC == 9.8.2
+  , GHC == 9.10.1
+  , GHC == 9.12.1
 
 source-repository head
   type: git

--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -38,7 +38,11 @@ tested-with:
   , GHC == 8.6.5
   , GHC == 8.8.3
   , GHC == 8.10.1
-  , GHC == 9.2.1
+  , GHC == 9.2.7
+  , GHC == 9.4.4
+  , GHC == 9.8.2
+  , GHC == 9.10.1
+  , GHC == 9.12.1
 extra-source-files:
   README.md
   CHANGELOG.md
@@ -71,7 +75,7 @@ library
     , resourcet                       >= 1.1        && < 1.4
     , safe-exceptions                 >= 0.1        && < 0.2
     , stm                             >= 2.4        && < 2.6
-    , template-haskell                >= 2.10       && < 2.23
+    , template-haskell                >= 2.10       && < 2.24
     , text                            >= 1.1        && < 2.2
     , time                            >= 1.4        && < 1.15
     , transformers                    >= 0.5        && < 0.7


### PR DESCRIPTION
This is a small PR that brings explicit support for GHC 9.12.

The only required change was allowing template-haskell-2.23. This means that no new releases are required; a Hackage revision will suffice.

I have also taken the liberty of updating the Github Action to also test GHC 9.12, and also update the cabal files to specify tested GHC versions.