### PR TITLE
Bump upper bounds for containers and random

### DIFF
--- a/hedgehog-example/hedgehog-example.cabal
+++ b/hedgehog-example/hedgehog-example.cabal
@@ -59,7 +59,7 @@ library
     , hedgehog-quickcheck
     , base                            >= 3          && < 5
     , barbies
-    , containers                      >= 0.4        && < 0.8
+    , containers                      >= 0.4        && < 0.9
     , directory                       >= 1.0        && < 1.4
     , filepath                        >= 1.3        && < 1.6
     , hashtables                      >= 1.2        && < 1.5

--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -62,7 +62,7 @@ library
     , barbies                         >= 1.0        && < 2.2
     , bytestring                      >= 0.10       && < 0.13
     , concurrent-output               >= 1.7        && < 1.11
-    , containers                      >= 0.4        && < 0.8
+    , containers                      >= 0.4        && < 0.9
     , deepseq                         >= 1.1.0.0    && < 1.6
     , directory                       >= 1.2        && < 1.4
     , erf                             >= 2.0        && < 2.1
@@ -149,7 +149,7 @@ test-suite test
   build-depends:
       hedgehog
     , base                            >= 3          && < 5
-    , containers                      >= 0.4        && < 0.8
+    , containers                      >= 0.4        && < 0.9
     , mmorph                          >= 1.0        && < 1.3
     , mtl                             >= 2.1        && < 2.4
     , pretty-show                     >= 1.6        && < 1.11

--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -73,7 +73,7 @@ library
     , mtl                             >= 2.1        && < 2.4
     , pretty-show                     >= 1.6        && < 1.11
     , primitive                       >= 0.6        && < 0.10
-    , random                          >= 1.1        && < 1.3
+    , random                          >= 1.1        && < 1.4
     , resourcet                       >= 1.1        && < 1.4
     , safe-exceptions                 >= 0.1        && < 0.2
     , stm                             >= 2.4        && < 2.6


### PR DESCRIPTION
Bump upper bounds for containers to < 0.9 and random to < 1.4.

Resolves https://github.com/hedgehogqa/haskell-hedgehog/issues/542, https://github.com/hedgehogqa/haskell-hedgehog/issues/543.
