### PR TITLE
Give a better implementation for `(*>)`

### DIFF
--- a/hedgehog/src/Hedgehog/Internal/Gen.hs
+++ b/hedgehog/src/Hedgehog/Internal/Gen.hs
@@ -499,6 +499,9 @@ instance Functor m => Functor (GenT m) where
 --
 -- implementation: parallel shrinking
 --
+-- | This Applicative instance is not lawful with regards to the Monad instance.
+-- This is because using applicative allows us to do parallel shrinking, but
+-- Monad does not allow that.
 instance Monad m => Applicative (GenT m) where
   pure =
     fromTreeMaybeT . pure

--- a/hedgehog/src/Hedgehog/Internal/Gen.hs
+++ b/hedgehog/src/Hedgehog/Internal/Gen.hs
@@ -528,9 +528,6 @@ instance Monad m => Applicative (GenT m) where
 --          runGenT size sm m
 
 instance Monad m => Monad (GenT m) where
-  return =
-    pure
-
   (>>=) m k =
     GenT $ \size seed ->
       case Seed.split seed of

--- a/hedgehog/src/Hedgehog/Internal/Property.hs
+++ b/hedgehog/src/Hedgehog/Internal/Property.hs
@@ -245,6 +245,7 @@ newtype TestT m a =
     } deriving (
       Functor
     , Applicative
+    , Monad
     , MonadIO
     , MonadBase b
     , MonadThrow
@@ -689,15 +690,6 @@ newtype Coverage a =
 
 ------------------------------------------------------------------------
 -- TestT
-
-instance Monad m => Monad (TestT m) where
-  return =
-    pure
-
-  (>>=) m k =
-    TestT $
-      unTest m >>=
-      unTest . k
 
 instance Monad m => MonadFail (TestT m) where
   fail err =


### PR DESCRIPTION
~~The default implementation of `(*>)` uses `(<*>)` which tries to perform each branch in parallel. However, since we only get the value from the right argument, we should just return that argument.

I don't implement `(>>)` similarly due to my attempts with https://github.com/haskell/core-libraries-committee/issues/333, but if that proposal falls through I'll be back.~~

Simply cleanup some instance definitions and add a comment.