### PR TITLE
Update CI to use Ubuntu 24.04

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes:
       60
     container:


### PR DESCRIPTION
Ubuntu 20.04 support has been discontinued by Github on 1st April 2025, which breaks our CI as no such runners are available anymore.

Let's follow https://github.com/haskell-CI/haskell-ci/pull/770 to switch to Ubuntu 24.04 to get around it.