### PR TITLE
Update Hedgehog link to point to Hackage

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ https://preview.webflow.com/preview/hedgehogqa?utm_medium=preview_link&utm_sourc
 
 <div align="left">
 
-[Hedgehog](http://hedgehog.qa/) automatically generates a comprehensive array of test cases, exercising your software in ways human testers would never imagine.
+[Hedgehog](https://hackage.haskell.org/package/hedgehog) automatically generates a comprehensive array of test cases, exercising your software in ways human testers would never imagine.
 
 Generate hundreds of test cases automatically, exposing even the most insidious of corner cases. Failures are automatically simplified, giving developers coherent, intelligible error messages.
 


### PR DESCRIPTION
See https://github.com/hedgehogqa/haskell-hedgehog/issues/518.