### PR TITLE
Bump dependency upper bounds

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -30,7 +30,7 @@ jobs:
         include:
           - compiler: ghc-9.14.1
             compilerKind: ghc
-            compilerVersion: 9.12.1
+            compilerVersion: 9.14.1
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.12.1

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -28,6 +28,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.14.1
+            compilerKind: ghc
+            compilerVersion: 9.12.1
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.12.1
             compilerKind: ghc
             compilerVersion: 9.12.1

--- a/cabal.project
+++ b/cabal.project
@@ -28,3 +28,7 @@ package hedgehog-quickcheck
   ghc-options: -Wall -Werror
 package hedgehog-test-laws
   ghc-options: -Wall -Werror
+
+if impl(ghc >= 9.14)
+  allow-newer:
+    , lifted-async:base

--- a/hedgehog-example/hedgehog-example.cabal
+++ b/hedgehog-example/hedgehog-example.cabal
@@ -70,9 +70,9 @@ library
     , parsec                          >= 3.1        && < 3.2
     , pretty-show                     >= 1.6        && < 1.11
     , process                         >= 1.2        && < 1.7
-    , QuickCheck                      >= 2.7        && < 2.17
+    , QuickCheck                      >= 2.7        && < 2.19
     , resourcet                       >= 1.1        && < 1.4
-    , template-haskell                >= 2.10       && < 2.24
+    , template-haskell                >= 2.10       && < 2.25
     , temporary                       >= 1.3        && < 1.4
     , temporary-resourcet             >= 0.1        && < 0.2
     , text                            >= 1.1        && < 2.2

--- a/hedgehog-quickcheck/hedgehog-quickcheck.cabal
+++ b/hedgehog-quickcheck/hedgehog-quickcheck.cabal
@@ -58,7 +58,7 @@ library
   build-depends:
       base                            >= 3          && < 5
     , hedgehog                        >= 0.5        && < 1.8
-    , QuickCheck                      >= 2.7        && < 2.17
+    , QuickCheck                      >= 2.7        && < 2.19
     , transformers                    >= 0.4        && < 0.7
 
   ghc-options:

--- a/hedgehog-test-laws/hedgehog-test-laws.cabal
+++ b/hedgehog-test-laws/hedgehog-test-laws.cabal
@@ -61,10 +61,10 @@ test-suite test
       hedgehog
     , base                            >= 3          && < 5
     , checkers                        >= 0.5        && < 0.8
-    , QuickCheck                      >= 2.10       && < 2.17
+    , QuickCheck                      >= 2.10       && < 2.19
     , tasty                           >= 1.2        && < 1.6
-    , tasty-expected-failure          >= 0.11       && < 0.12
-    , tasty-quickcheck                >= 0.10       && < 0.11
+    , tasty-expected-failure          >= 0.11       && < 0.13
+    , tasty-quickcheck                >= 0.10       && < 0.12
     , transformers                    >= 0.5        && < 0.7
 
   if impl(ghc < 8.0)


### PR DESCRIPTION
Tested locally with `ghc-9.14.1`.

Would appreciate a Hackage metadata edit to make the Hackage deps align with the deps in this PR. If you give me the OK here in this ticket, I can even do the Hackage metadata edit (as a Hackage Trustee).