### PR TITLE
Treat string literals as code when classifying comments

### DIFF
--- a/hedgehog/hedgehog.cabal
+++ b/hedgehog/hedgehog.cabal
@@ -140,6 +140,7 @@ test-suite test
   other-modules:
     Test.Hedgehog.Applicative
     Test.Hedgehog.Confidence
+    Test.Hedgehog.Discovery
     Test.Hedgehog.Filter
     Test.Hedgehog.Maybe
     Test.Hedgehog.Range

--- a/hedgehog/src/Hedgehog/Internal/Discovery.hs
+++ b/hedgehog/src/Hedgehog/Internal/Discovery.hs
@@ -180,6 +180,23 @@ classified =
       x : xs ->
         ok x : string k xs
 
+    -- Consume a multiline string literal body after the opening @"""@, up to
+    -- and including the closing @"""@, honouring backslash escapes. As with
+    -- ordinary strings, its contents are code, so a "{-" inside one must not
+    -- open a comment.
+    multiline k = \case
+      [] ->
+        []
+
+      x@(Pos _ '\\') : y : xs ->
+        ok x : ok y : multiline k xs
+
+      x@(Pos _ '"') : y@(Pos _ '"') : z@(Pos _ '"') : xs ->
+        ok x : ok y : ok z : k xs
+
+      x : xs ->
+        ok x : multiline k xs
+
     loop nesting in_line = \case
       [] ->
         []
@@ -198,6 +215,9 @@ classified =
 
       x@(Pos _ '\'') : y@(Pos _ '\\') : z@(Pos _ '"') : w@(Pos _ '\'') : xs | nesting <= 0 ->
         ok x : ok y : ok z : ok w : loop nesting in_line xs
+
+      x@(Pos _ '"') : y@(Pos _ '"') : z@(Pos _ '"') : xs | nesting <= 0 ->
+        ok x : ok y : ok z : multiline (loop nesting in_line) xs
 
       x@(Pos _ '"') : xs | nesting <= 0 ->
         ok x : string (loop nesting in_line) xs

--- a/hedgehog/src/Hedgehog/Internal/Discovery.hs
+++ b/hedgehog/src/Hedgehog/Internal/Discovery.hs
@@ -164,6 +164,22 @@ classified =
     ko =
       Classified Comment
 
+    -- Consume a string literal body after the opening quote, up to and
+    -- including the closing quote, honouring backslash escapes. Characters
+    -- inside a string are code, so a "{-" within it must not open a comment.
+    string k = \case
+      [] ->
+        []
+
+      x@(Pos _ '\\') : y : xs ->
+        ok x : ok y : string k xs
+
+      x@(Pos _ '"') : xs ->
+        ok x : k xs
+
+      x : xs ->
+        ok x : string k xs
+
     loop nesting in_line = \case
       [] ->
         []
@@ -173,6 +189,9 @@ classified =
 
       x : xs | in_line ->
         ko x : loop nesting in_line xs
+
+      x@(Pos _ '"') : xs | nesting <= 0 ->
+        ok x : string (loop nesting in_line) xs
 
       x@(Pos _ '{') : y@(Pos _ '-') : xs ->
         ko x : ko y : loop (nesting + 1) in_line xs

--- a/hedgehog/src/Hedgehog/Internal/Discovery.hs
+++ b/hedgehog/src/Hedgehog/Internal/Discovery.hs
@@ -190,6 +190,15 @@ classified =
       x : xs | in_line ->
         ko x : loop nesting in_line xs
 
+      -- A double quote inside a character literal, i.e. '"' or '\"', must
+      -- not start a string literal. Other character literals cannot affect
+      -- classification, so they need no special handling here.
+      x@(Pos _ '\'') : y@(Pos _ '"') : z@(Pos _ '\'') : xs | nesting <= 0 ->
+        ok x : ok y : ok z : loop nesting in_line xs
+
+      x@(Pos _ '\'') : y@(Pos _ '\\') : z@(Pos _ '"') : w@(Pos _ '\'') : xs | nesting <= 0 ->
+        ok x : ok y : ok z : ok w : loop nesting in_line xs
+
       x@(Pos _ '"') : xs | nesting <= 0 ->
         ok x : string (loop nesting in_line) xs
 

--- a/hedgehog/test/Test/Hedgehog/Discovery.hs
+++ b/hedgehog/test/Test/Hedgehog/Discovery.hs
@@ -31,6 +31,70 @@ prop_string_with_comment_token_is_not_a_comment =
 
     found === ["prop_after"]
 
+-- | A double quote inside a character literal must not open a string,
+--   otherwise the next real string flips the classifier inside-out and a
+--   @{-@ in that string hides the declarations that follow it.
+--
+prop_char_literal_quote_is_not_a_string :: Property
+prop_char_literal_quote_is_not_a_string =
+  withTests 1 . property $
+    discovered
+      [ "module Test where"
+      , ""
+      , "quote = '\"'"
+      , ""
+      , "banner = \"{- inside a string\""
+      , ""
+      , "prop_after = ()"
+      ] === ["prop_after"]
+
+-- | An escaped quote must not end the string early, otherwise the @{-@
+--   after it opens a block comment.
+--
+prop_escaped_quote_does_not_end_string :: Property
+prop_escaped_quote_does_not_end_string =
+  withTests 1 . property $
+    discovered
+      [ "module Test where"
+      , ""
+      , "banner = \"\\\" {- still inside\""
+      , ""
+      , "prop_after = ()"
+      ] === ["prop_after"]
+
+-- | A @--@ inside a string literal is not a line comment.
+--
+prop_line_comment_token_in_string_is_code :: Property
+prop_line_comment_token_in_string_is_code =
+  withTests 1 . property $
+    discovered
+      [ "module Test where"
+      , ""
+      , "dashes = \"-- {-\""
+      , ""
+      , "prop_after = ()"
+      ] === ["prop_after"]
+
+-- | Block comment tokens inside a string literal must not change the
+--   comment nesting level.
+--
+prop_block_comment_tokens_in_string_are_code :: Property
+prop_block_comment_tokens_in_string_are_code =
+  withTests 1 . property $
+    discovered
+      [ "module Test where"
+      , ""
+      , "block = \"{- -}\""
+      , ""
+      , "banner = \"{- inside a string\""
+      , ""
+      , "prop_after = ()"
+      ] === ["prop_after"]
+
+discovered :: [String] -> [String]
+discovered =
+  fmap unPropertyName . Map.keys . findProperties "prop_" "Test.hs" . unlines
+
 tests :: IO Bool
 tests =
   checkParallel $$(discover)

--- a/hedgehog/test/Test/Hedgehog/Discovery.hs
+++ b/hedgehog/test/Test/Hedgehog/Discovery.hs
@@ -91,6 +91,24 @@ prop_block_comment_tokens_in_string_are_code =
       , "prop_after = ()"
       ] === ["prop_after"]
 
+-- | A @{-@ inside a multiline string literal is code, not the start of a
+--   block comment, so declarations after one are still discovered. An odd
+--   double quote within the body must not leave the classifier mid-string
+--   when the closing @"""@ is reached.
+--
+prop_block_comment_token_in_multiline_string_is_code :: Property
+prop_block_comment_token_in_multiline_string_is_code =
+  withTests 1 . property $
+    discovered
+      [ "module Test where"
+      , ""
+      , "banner ="
+      , "  \"\"\"say \" and {- not a comment"
+      , "  still inside\"\"\""
+      , ""
+      , "prop_after = ()"
+      ] === ["prop_after"]
+
 discovered :: [String] -> [String]
 discovered =
   fmap unPropertyName . Map.keys . findProperties "prop_" "Test.hs" . unlines

--- a/hedgehog/test/Test/Hedgehog/Discovery.hs
+++ b/hedgehog/test/Test/Hedgehog/Discovery.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Test.Hedgehog.Discovery where
+
+import qualified Data.Map as Map
+
+import           Hedgehog
+import           Hedgehog.Internal.Discovery (findProperties)
+import           Hedgehog.Internal.Property (unPropertyName)
+
+-- | A @"{-"@ appearing inside a string literal must not be treated as the
+--   start of a block comment, otherwise every declaration after it is hidden
+--   from property discovery.
+--
+--   https://github.com/hedgehogqa/haskell-hedgehog/issues/570
+--
+prop_string_with_comment_token_is_not_a_comment :: Property
+prop_string_with_comment_token_is_not_a_comment =
+  withTests 1 . property $ do
+    let
+      source =
+        unlines
+          [ "module Test where"
+          , ""
+          , "brace = \"{-\""
+          , ""
+          , "prop_after = ()"
+          ]
+
+      found =
+        fmap unPropertyName . Map.keys $ findProperties "prop_" "Test.hs" source
+
+    found === ["prop_after"]
+
+tests :: IO Bool
+tests =
+  checkParallel $$(discover)

--- a/hedgehog/test/test.hs
+++ b/hedgehog/test/test.hs
@@ -2,6 +2,7 @@ import           Hedgehog.Main (defaultMain)
 
 import qualified Test.Hedgehog.Applicative
 import qualified Test.Hedgehog.Confidence
+import qualified Test.Hedgehog.Discovery
 import qualified Test.Hedgehog.Filter
 import qualified Test.Hedgehog.Maybe
 import qualified Test.Hedgehog.Seed
@@ -15,6 +16,7 @@ main =
   defaultMain [
       Test.Hedgehog.Applicative.tests
     , Test.Hedgehog.Confidence.tests
+    , Test.Hedgehog.Discovery.tests
     , Test.Hedgehog.Filter.tests
     , Test.Hedgehog.Maybe.tests
     , Test.Hedgehog.Seed.tests


### PR DESCRIPTION
Fixes #570. `classified` treated a `{-` inside a string literal as the start of a block comment, so any declaration after a line like `a = "{-"` was hidden and the source rendering for failing properties broke. This skips over string literal bodies (honouring backslash escapes) so their contents are always classified as code, and adds a Discovery test that the property after such a line is still found.